### PR TITLE
Swap win10 network interfaces

### DIFF
--- a/hosts/zeus/configuration.nix
+++ b/hosts/zeus/configuration.nix
@@ -82,7 +82,6 @@ in {
 
   mine.gnupg.enable = true;
   mine.useColemakKeyboardLayout = true;
-  mine.virtualisation.docker.enable = true;
   mine.virtualisation.libvirtd.enable = true;
 
   mine.hardware.machine = "zeus";

--- a/hosts/zeus/configuration.nix
+++ b/hosts/zeus/configuration.nix
@@ -6,7 +6,7 @@ let
 
   pinnedNH = import ../../external/nixos-hardware.nix;
 
-  nasIP = "172.25.1.2";
+  nasIP = "172.25.2.2";
 
   buildWindows10 = env: let
     vmName = if env == "prod" then "win10"
@@ -32,9 +32,11 @@ let
         else if env == "staging" then "02:68:b3:29:da:98"
         else abort "${env} is not supported";
 
-        dev_path = if env == "prod" then "/dev/disk/by-path/ip-172.25.1.2:3260-iscsi-iqn.2018-11.com.nasreddine.apollo:win10-lun-1"
-        else if env == "staging" then "/dev/disk/by-path/ip-172.25.1.2:3260-iscsi-iqn.2018-11.com.nasreddine.apollo:win10.staging-lun-1"
+        dev_path = if env == "prod" then "/dev/disk/by-path/ip-${nasIP}:3260-iscsi-iqn.2018-11.com.nasreddine.apollo:win10-lun-1"
+        else if env == "staging" then "/dev/disk/by-path/ip-${nasIP}:3260-iscsi-iqn.2018-11.com.nasreddine.apollo:win10.staging-lun-1"
         else abort "${env} is not supported";
+
+        source_dev = "ifcns1";
       };
 
     in ''

--- a/hosts/zeus/win10.xml
+++ b/hosts/zeus/win10.xml
@@ -95,7 +95,7 @@
     </controller>
     <interface type='direct'>
       <mac address='@mac_address@'/>
-      <source dev='ifcns2' mode='bridge'/>
+      <source dev='@source_dev@' mode='bridge'/>
       <target dev='macvtap0'/>
       <model type='rtl8139'/>
       <alias name='net0'/>


### PR DESCRIPTION
My entire NS network is geared towards NS1 being the primary network
interface. For instance, apollo.nasreddine.com resolves to NS1 address
that is not accessible from NS2 so I cannot use NS2 for the network
access!