### PR TITLE
nixos: fix the nixos-version broken by the nixpkgs pinning

### DIFF
--- a/modules/nixos/general/version.nix
+++ b/modules/nixos/general/version.nix
@@ -25,7 +25,10 @@
 
 let
   git_dir = ../../../.git;
-  label = "nixos_${config.system.nixos.version}-shabka_" + (if lib.pathIsDirectory git_dir then
+
+  pinnedNixpkgsVersion = builtins.fromJSON (builtins.readFile ../../../external/nixpkgs-stable-version.json);
+
+  label = "nixos_${config.system.nixos.release}-${builtins.substring 0 7 pinnedNixpkgsVersion.rev}-shabka_" + (if lib.pathIsDirectory git_dir then
     "${builtins.substring 0 7 (lib.commitIdFromGitRepo git_dir)}"
   else "story");
 


### PR DESCRIPTION
When the nixpkgs is pinned using `builtins.fetchGit` instead of a
channel, NixOS lose track of the commit because the fetcher removes the
`.git` folder. This changeset constructs the nixos-version back using
the `system.nixos.release` stitched with the first seven characters of
the revision in the JSON file describing the nixpkgs source.

closes #87