### PR TITLE
external/home-manager: update to c48fd9d

### DIFF
--- a/external/home-manager-version.json
+++ b/external/home-manager-version.json
@@ -1,8 +1,8 @@
 {
   "url": "https://github.com/rycee/home-manager.git",
-  "rev": "16946a6f008afa13911805418217dbd92f1fedde",
-  "date": "2019-01-03T10:51:37+01:00",
-  "sha256": "09h2b6v6a9q4rr1cp68njzpzji93mi17wh3s01l166jp5apciq5n",
+  "rev": "c48fd9d8422519d6f171e7cfc301743d28d08631",
+  "date": "2019-01-10T01:39:01+01:00",
+  "sha256": "1n2m6y6alc5bfkdlvpxc1zikn6cggnslhamyrjvbkhlkryxhx2r4",
   "fetchSubmodules": false,
   "ref": "refs/heads/master"
 }

--- a/external/home-manager.nix
+++ b/external/home-manager.nix
@@ -15,21 +15,7 @@ let
 
   mkAssertMsg = name: "${name} is available upsteam, kill this patch";
 
-  patches = [
-    # https://github.com/rycee/home-manager/pull/529
-    (
-      let
-        importPinned.programs.autorandr.profiles = {
-          "default" = { config = { eDP1 = {}; }; };
-        };
-      in
-        assert assertMsg (! importPinned.programs.autorandr.profiles."default".config.eDP1 ? transform) (mkAssertMsg "transform");
-        fetchpatch {
-          url = "https://github.com/rycee/home-manager/pull/529.patch";
-          sha256 = "0k8x79wla8nfrjr57wfx05kcxv4yjbjhaaa2l91hhm75drjswiig";
-        }
-    )
-  ];
+  patches = [];
 
   patched = runCommand "home-manager-${pinnedVersion.rev}"
     {

--- a/modules/home/generic/non-nixos.nix
+++ b/modules/home/generic/non-nixos.nix
@@ -16,7 +16,7 @@ with lib;
     home.file = {
       "ssh/authorized_keys".source = builtins.fetchurl {
         url = "https://github.com/kalbasit.keys";
-        sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
+        sha256 = "1ijzn5nmh7fcpky9zz6dsbps3pad67nlp0cs0zrs46f0bcy9cqjr";
       };
     };
 

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -6,7 +6,7 @@ let
   sshKeys = [
     (builtins.readFile (builtins.fetchurl {
       url = "https://github.com/kalbasit.keys";
-      sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
+      sha256 = "1ijzn5nmh7fcpky9zz6dsbps3pad67nlp0cs0zrs46f0bcy9cqjr";
     }))
   ];
 


### PR DESCRIPTION
rycee/home-manager#529 is now merged and the patch is no longer needed.