### PR TITLE
external/nixpkgs-unstable: revert back to 44b02b

### DIFF
--- a/external/nixpkgs-unstable-version.json
+++ b/external/nixpkgs-unstable-version.json
@@ -1,8 +1,8 @@
 {
   "url": "https://github.com/NixOS/nixpkgs-channels.git",
-  "rev": "eebd1a9263716a04689a37b6537e50801d376b5e",
-  "date": "2019-01-03T20:01:07+01:00",
-  "sha256": "0s1fylhjqp2h4j044iwbwndgnips3nrynh2ip5ijh96kavizf2gb",
+  "rev": "44b02b52ea6a49674f124f50009299f192ed78bb",
+  "date": "2018-12-14T14:08:15+00:00",
+  "sha256": "0gmk6w1lnp6kjf26ak8jzj0h2qrnk7bin54gq68w1ky2pdijnc44",
   "fetchSubmodules": false,
   "ref": "refs/heads/nixos-unstable"
 }


### PR DESCRIPTION
This partially reverts commit 7b8c42422a14dbc87731dfc4236c6eaf0abb2e0b.

closes #98