### PR TITLE
hosts/cratos: switch to the unstable kernel version 4.20.3

### DIFF
--- a/modules/nixos/hardware/xps-13.nix
+++ b/modules/nixos/hardware/xps-13.nix
@@ -26,9 +26,11 @@ with lib;
 
     services.xserver.videoDrivers = lib.mkForce ["modesetting"];
 
-    # use unstable kernel and Virtualbox from unstable so it compiles
+    # use unstable kernel to fix modesetting issues that turn the screen black.
+    # TODO: unfortunately Virtualbox is not working with this kernel so I'm
+    # going to disable it.
     boot.kernelPackages = pkgs.unstable.linuxPackages_latest;
-    virtualisation.virtualbox.host.package = pkgs.unstable.virtualbox;
+    mine.workstation.virtualbox.enable = mkForce false;
 
     i18n.consoleFont = "Lat2-Terminus16";
   };

--- a/modules/nixos/hardware/xps-13.nix
+++ b/modules/nixos/hardware/xps-13.nix
@@ -26,7 +26,9 @@ with lib;
 
     services.xserver.videoDrivers = lib.mkForce ["modesetting"];
 
-    boot.kernelPackages = pkgs.linuxPackages_latest;
+    # use unstable kernel and Virtualbox from unstable so it compiles
+    boot.kernelPackages = pkgs.unstable.linuxPackages_latest;
+    virtualisation.virtualbox.host.package = pkgs.unstable.virtualbox;
 
     i18n.consoleFont = "Lat2-Terminus16";
   };


### PR DESCRIPTION
fixes #138