### PR TITLE
hosts/cratos: use the xps-9380 nixos hardware profile

### DIFF
--- a/external/nixos-hardware.nix
+++ b/external/nixos-hardware.nix
@@ -1,7 +1,34 @@
+{ fetchpatch, runCommand }:
+
 let
   pinnedVersion = builtins.fromJSON (builtins.readFile ./nixos-hardware-version.json);
   pinned = builtins.fetchTarball {
     inherit (pinnedVersion) url sha256;
   };
+
+  patches = [
+    # Dell XPS 9380 hardware profile
+    # https://github.com/NixOS/nixos-hardware/pull/97
+    (fetchpatch {
+      url = "https://github.com/NixOS/nixos-hardware/pull/97.patch";
+      sha256 = "1pryw8kwk8h99ag08wni6gmkyrpabgyzm55lf8b6zd25ph4027m5";
+    })
+  ];
+
+  patched = runCommand "nixos-hardware-${pinnedVersion.rev}"
+    {
+      inherit pinned patches;
+
+      preferLocalBuild = true;
+    }
+    ''
+      cp -r $pinned $out
+      chmod -R +w $out
+      for p in $patches; do
+        echo "Applying patch $p";
+        patch -d $out -p1 < "$p";
+      done
+    '';
+
 in
-  pinned
+  patched

--- a/hosts/cratos/configuration.nix
+++ b/hosts/cratos/configuration.nix
@@ -4,7 +4,16 @@ with lib;
 
 let
 
-  pinnedNH = import ../../external/nixos-hardware.nix;
+  pinnedNH =
+    # I'm getting an infinite loop when I import pkgs as a dependency to this
+    # function. Why is that? It forces me to import nixpkgs again here!
+    let
+
+      nixpkgs = (import ../../external/nixpkgs-stable.nix {});
+
+    in import ../../external/nixos-hardware.nix {
+      inherit (import nixpkgs {}) fetchpatch runCommand;
+    };
 
   nasreddineCA = builtins.readFile (builtins.fetchurl {
     url = "https://kalbas.it/ca.crt";
@@ -26,23 +35,12 @@ in {
   imports = [
     ./hardware-configuration.nix
 
-    # "${pinnedNH}/dell/xps/13-9370"
-    "${pinnedNH}/common/pc/laptop"
-    "${pinnedNH}/common/pc/laptop/acpi_call.nix"
-    "${pinnedNH}/common/pc/laptop/cpu-throttling-bug.nix"
-    "${pinnedNH}/common/cpu/intel"
+    "${pinnedNH}/dell/xps/13-9380"
 
     ../../modules/nixos
 
     ./home.nix
   ];
-
-
-  # Force S3 sleep mode. See README.wiki for details.
-  boot.kernelParams = [ "mem_sleep_default=deep" ];
-
-  # touchpad goes over i2c
-  boot.blacklistedKernelModules = [ "psmouse" ];
 
   boot.tmpOnTmpfs = true;
 

--- a/hosts/cratos/configuration.nix
+++ b/hosts/cratos/configuration.nix
@@ -26,12 +26,23 @@ in {
   imports = [
     ./hardware-configuration.nix
 
-    "${pinnedNH}/dell/xps/13-9370"
+    # "${pinnedNH}/dell/xps/13-9370"
+    "${pinnedNH}/common/pc/laptop"
+    "${pinnedNH}/common/pc/laptop/acpi_call.nix"
+    "${pinnedNH}/common/pc/laptop/cpu-throttling-bug.nix"
+    "${pinnedNH}/common/cpu/intel"
 
     ../../modules/nixos
 
     ./home.nix
   ];
+
+
+  # Force S3 sleep mode. See README.wiki for details.
+  boot.kernelParams = [ "mem_sleep_default=deep" ];
+
+  # touchpad goes over i2c
+  boot.blacklistedKernelModules = [ "psmouse" ];
 
   boot.tmpOnTmpfs = true;
 

--- a/hosts/hades/configuration.nix
+++ b/hosts/hades/configuration.nix
@@ -4,7 +4,16 @@ with lib;
 
 let
 
-  pinnedNH = import ../../external/nixos-hardware.nix;
+  pinnedNH =
+    # I'm getting an infinite loop when I import pkgs as a dependency to this
+    # function. Why is that? It forces me to import nixpkgs again here!
+    let
+
+      nixpkgs = (import ../../external/nixpkgs-stable.nix {});
+
+    in import ../../external/nixos-hardware.nix {
+      inherit (import nixpkgs {}) fetchpatch runCommand;
+    };
 
   nasreddineCA = builtins.readFile (builtins.fetchurl {
     url = "https://kalbas.it/ca.crt";

--- a/hosts/hera/configuration.nix
+++ b/hosts/hera/configuration.nix
@@ -4,7 +4,16 @@ with lib;
 
 let
 
-  pinnedNH = import ../../external/nixos-hardware.nix;
+  pinnedNH =
+    # I'm getting an infinite loop when I import pkgs as a dependency to this
+    # function. Why is that? It forces me to import nixpkgs again here!
+    let
+
+      nixpkgs = (import ../../external/nixpkgs-stable.nix {});
+
+    in import ../../external/nixos-hardware.nix {
+      inherit (import nixpkgs {}) fetchpatch runCommand;
+    };
 
   nasreddineCA = builtins.readFile (builtins.fetchurl {
     url = "https://kalbas.it/ca.crt";

--- a/hosts/zeus/configuration.nix
+++ b/hosts/zeus/configuration.nix
@@ -7,7 +7,16 @@ let
     (builtins.readFile (import ../../external/kalbasit-keys.nix))
   ];
 
-  pinnedNH = import ../../external/nixos-hardware.nix;
+  pinnedNH =
+    # I'm getting an infinite loop when I import pkgs as a dependency to this
+    # function. Why is that? It forces me to import nixpkgs again here!
+    let
+
+      nixpkgs = (import ../../external/nixpkgs-stable.nix {});
+
+    in import ../../external/nixos-hardware.nix {
+      inherit (import nixpkgs {}) fetchpatch runCommand;
+    };
 
   nasIP = "172.25.2.2";
 

--- a/modules/nixos/hardware/xps-13.nix
+++ b/modules/nixos/hardware/xps-13.nix
@@ -26,11 +26,7 @@ with lib;
 
     services.xserver.videoDrivers = lib.mkForce ["modesetting"];
 
-    # use unstable kernel to fix modesetting issues that turn the screen black.
-    # TODO: unfortunately Virtualbox is not working with this kernel so I'm
-    # going to disable it.
-    boot.kernelPackages = pkgs.unstable.linuxPackages_latest;
-    mine.workstation.virtualbox.enable = mkForce false;
+    boot.kernelPackages = pkgs.linuxPackages_latest;
 
     i18n.consoleFont = "Lat2-Terminus16";
   };


### PR DESCRIPTION
I was getting black screens and random lockups when using the XPS 9370 profile. It turned out to be due to the changes specific to Kaby Lake that are being imported. This CPU is actually Whiskey Lake. The profile also disables a bug fix that is not present on this model.

See https://github.com/NixOS/nixos-hardware/pull/97

fixes #138 