### PR TITLE
Fix the build commands for hosts

### DIFF
--- a/hosts/athena/default.nix
+++ b/hosts/athena/default.nix
@@ -1,6 +1,6 @@
 with import ../../util;
 
 {
-  # athena = buildNixDarwinConfiguration ./darwin-configuration.nix;
-  athena-home = buildHomeManagerConfiguration ./home.nix;
+  # darwin = buildNixDarwinConfiguration ./darwin-configuration.nix;
+  home = buildHomeManagerConfiguration ./home.nix;
 }

--- a/hosts/cratos/default.nix
+++ b/hosts/cratos/default.nix
@@ -1,5 +1,12 @@
 with import ../../util;
 
-{
-  cratos = buildNixOSConfiguration { conf = ./configuration.nix; };
+rec {
+  nixos = buildNixOSConfiguration { conf = ./configuration.nix; };
+  home = (import ./home.nix).mine.home-manager.config {
+    userName = "yl";
+    uid = 2000;
+    isAdmin = true;
+    home = "/yl";
+    nixosConfig = nixos.config;
+  };
 }

--- a/hosts/hades/default.nix
+++ b/hosts/hades/default.nix
@@ -1,12 +1,12 @@
 with import ../../util;
 
-{
-  hades = buildNixOSConfiguration { conf = ./configuration.nix; };
-  hades-home = (import ./home.nix).mine.home-manager.config {
+rec {
+  nixos = buildNixOSConfiguration { conf = ./configuration.nix; };
+  home = buildHomeManagerConfiguration ((import ./home.nix).mine.home-manager.config {
     userName = "yl";
     uid = 2000;
     isAdmin = true;
     home = "/yl";
-    nixosConfig = {};
-  };
+    nixosConfig = nixos.config;
+  } { lib = (import <nixpkgs>).lib; });
 }

--- a/util/buildHomeManagerConfiguration.nix
+++ b/util/buildHomeManagerConfiguration.nix
@@ -10,5 +10,5 @@ in {
   buildHomeManagerConfiguration = conf: (import "${homeManager}/home-manager/home-manager.nix" {
     confPath = conf;
     confAttr = "";
-  }).activationPackage;
+  });
 }

--- a/util/buildNixDarwinConfiguration.nix
+++ b/util/buildNixDarwinConfiguration.nix
@@ -3,5 +3,5 @@
 {
   buildNixDarwinConfiguration = conf: (import <darwin> {
     configuration = conf;
-  }).system;
+  });
 }

--- a/util/buildNixOSConfiguration.nix
+++ b/util/buildNixOSConfiguration.nix
@@ -19,5 +19,5 @@ let
 in {
   buildNixOSConfiguration = {conf, withShim ? false}: (import <nixpkgs/nixos> {
     configuration.imports = [conf] ++ (if withShim then [ shim ] else []);
-  }).system;
+  });
 }


### PR DESCRIPTION
Each host's default should be able to build the home-manager and the NixOS/Darwin so they can be tested on Hydra once Hydra is live.