### PR TITLE
[NeoVim] Update the use of BetterWhitespace plugin

### DIFF
--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -194,7 +194,9 @@ let g:AutoPairsMultilineClose = 0
 "}}}
 "" BetterWhitespace{{{
 
-autocmd BufEnter * EnableStripWhitespaceOnSave
+let g:better_whitespace_enabled=1
+let g:strip_whitespace_on_save=1
+let g:strip_whitespace_confirm=0
 
 "}}}
 "" Deoplete{{{


### PR DESCRIPTION
[Better Whitespace](https://github.com/ntpeters/vim-better-whitespace)
has been updated upstream to no longer require the BufEnter command, but
it's also now asking for confirmation when trimming white spaces on save
by default. I don't desire to confirm on every save, I will disable it
with `:DisableStripWhitespaceOnSave` if I'm editing a file and would
like to conserve them.