### PR TITLE
external/home-manager: Install packages through NixOS users.users.<name?>.packages

### DIFF
--- a/external/home-manager-version.json
+++ b/external/home-manager-version.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/rycee/home-manager/archive/a3462daeb10ba908396aaa3aee521042a239d7ca.tar.gz",
-  "sha256": "169vyw5x43yvfibi441xzr8jirra9jm1c2m0zv4bndpb4hk850xd",
-  "rev": "a3462daeb10ba908396aaa3aee521042a239d7ca"
+  "url": "https://github.com/rycee/home-manager/archive/79731e6ab4d41ce4569fe6b60623a590675288af.tar.gz",
+  "sha256": "0myzxzkp5brw77k5kqn6nwwzka8cspvqchbjrg26j509qh0xkrmd",
+  "rev": "79731e6ab4d41ce4569fe6b60623a590675288af"
 }

--- a/modules/nixos/general/home-manager.nix
+++ b/modules/nixos/general/home-manager.nix
@@ -21,4 +21,8 @@ in {
       Function that returns the Home Manager configuration.
     '';
   };
+
+  config = {
+    home-manager.useUserPackages = true;
+  };
 }


### PR DESCRIPTION
Switch home manager to https://github.com/rycee/home-manager/pull/580 in order to install user packages through NixOS's user packages. This allows me to build VM that are able to have user packages.