### PR TITLE
nixos: do not install neovim, it shadows user's version

### DIFF
--- a/modules/nixos/general/editor.nix
+++ b/modules/nixos/general/editor.nix
@@ -1,10 +1,4 @@
-{ pkgs, ... }:
-
 {
   # set the EDITOR to neovim
   environment.variables.EDITOR = "nvim";
-
-  environment.systemPackages = with pkgs; [
-    neovim
-  ];
 }


### PR DESCRIPTION
In #159 the user packages are now installed through NixOS at `/etc/profiles/per-user/<per-user>/bin` which comes second after `/run/current-system/sw/bin` in the PATH so we cannot have `neovim` installed on the system. Use `mine.neovim.enable` coming from #142 to install it system-wide.