### PR TITLE
[Shell] Replace exa with ls/LS_COLORS

### DIFF
--- a/external/kalbasit-nur-version.json
+++ b/external/kalbasit-nur-version.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/kalbasit/nur-packages/archive/74a26aeae5ed5a8338679e1790796119086d92a3.tar.gz",
-  "sha256": "1ng9zj0z6nrqgw74s73hmpplvfx1a4zlar7l4h0jwyk59h19cliy",
-  "rev": "74a26aeae5ed5a8338679e1790796119086d92a3"
+  "url": "https://github.com/kalbasit/nur-packages/archive/e64b81d6e177809d2f8d9669373a9eb619972dea.tar.gz",
+  "sha256": "0jz5hclsc0xd2w8nf56hy3acm65cmhzg8xla26qdsvkis9pw7s5x",
+  "rev": "e64b81d6e177809d2f8d9669373a9eb619972dea"
 }

--- a/external/kalbasit-nur-version.json
+++ b/external/kalbasit-nur-version.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/kalbasit/nur-packages/archive/c84d1989b6068fd36f3f6a620f5a2b170b6733ea.tar.gz",
-  "sha256": "1p64zag5a15ykn3nnk7z6zyp7l2l60j8p0xz2n7404xlqh7jd93w",
-  "rev": "c84d1989b6068fd36f3f6a620f5a2b170b6733ea"
+  "url": "https://github.com/kalbasit/nur-packages/archive/74a26aeae5ed5a8338679e1790796119086d92a3.tar.gz",
+  "sha256": "1ng9zj0z6nrqgw74s73hmpplvfx1a4zlar7l4h0jwyk59h19cliy",
+  "rev": "74a26aeae5ed5a8338679e1790796119086d92a3"
 }

--- a/modules/home/software/zsh/default.nix
+++ b/modules/home/software/zsh/default.nix
@@ -106,6 +106,26 @@ let
     '';
   };
 
+  lsColors = stdenvNoCC.mkDerivation rec {
+    name = "lscolors-${version}";
+    version = "2019-02-01";
+
+    src = fetchFromGitHub {
+      owner = "trapd00r";
+      repo = "LS_COLORS";
+      rev = "ea316590b3f6c9784c21445bd575e16fc4b1ff2f";
+      sha256 = "1bj3q6s7yfglj7bpc8hjw05bz1byhm95ml2iyzr72vda4jn6ll7m";
+    };
+
+    buildPhase = ''
+      dircolors -b $src/LS_COLORS > ls-colors.zsh
+    '';
+
+    installPhase = ''
+      mv ls-colors.zsh $out
+    '';
+  };
+
 in {
 
   programs.zsh = mkMerge [
@@ -181,18 +201,20 @@ in {
         size = 1000000000;
       };
 
-      initExtra = builtins.readFile (substituteAll {
+      initExtra = ''
+        # source in the LS_COLORS
+        source "${lsColors}"
+      '' + (builtins.readFile (substituteAll {
         src = ./init-extra.zsh;
 
         bat_bin      = "${getBin bat}/bin/bat";
-        exa_bin      = "${getBin exa}/bin/exa";
         fortune_bin  = "${getBin fortune}/bin/fortune";
         fzf_bin      = "${getBin fzf}/bin/fzf-tmux";
         home_path    = "${config.home.homeDirectory}";
         jq_bin       = "${getBin jq}/bin/jq";
         less_bin     = "${getBin less}/bin/less";
         tput_bin     = "${getBin ncurses}/bin/tput";
-      });
+      }));
 
       oh-my-zsh = {
         enable = true;

--- a/modules/home/software/zsh/default.nix
+++ b/modules/home/software/zsh/default.nix
@@ -106,26 +106,6 @@ let
     '';
   };
 
-  lsColors = stdenvNoCC.mkDerivation rec {
-    name = "lscolors-${version}";
-    version = "2019-02-01";
-
-    src = fetchFromGitHub {
-      owner = "trapd00r";
-      repo = "LS_COLORS";
-      rev = "ea316590b3f6c9784c21445bd575e16fc4b1ff2f";
-      sha256 = "1bj3q6s7yfglj7bpc8hjw05bz1byhm95ml2iyzr72vda4jn6ll7m";
-    };
-
-    buildPhase = ''
-      dircolors -b $src/LS_COLORS > ls-colors.zsh
-    '';
-
-    installPhase = ''
-      mv ls-colors.zsh $out
-    '';
-  };
-
 in {
 
   programs.zsh = mkMerge [
@@ -203,7 +183,7 @@ in {
 
       initExtra = ''
         # source in the LS_COLORS
-        source "${lsColors}"
+        source "${nur.repos.kalbasit.ls-colors}/ls-colors/bourne-shell.sh"
       '' + (builtins.readFile (substituteAll {
         src = ./init-extra.zsh;
 

--- a/modules/home/software/zsh/init-extra.zsh
+++ b/modules/home/software/zsh/init-extra.zsh
@@ -317,9 +317,7 @@ export ERROR="${FG_RED_B}"
 
 # Find the option for using colors in ls, depending on the version
 if [[ -o interactive ]]; then
-	if type @exa_bin@ &>/dev/null; then
-		alias ls='@exa_bin@'
-	elif [[ "$OSTYPE" == netbsd* ]]; then
+	if [[ "$OSTYPE" == netbsd* ]]; then
 		# On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);
 		# otherwise, leave ls as is, because NetBSD's ls doesn't support -G
 		gls --color -d . &>/dev/null && alias ls='gls --color=tty'


### PR DESCRIPTION
TODO:
- [x] Move the package to NUR.
- [ ] ~Should I switch to https://github.com/trapd00r/zsh-syntax-highlighting-filetypes?~ It's outdated!