### PR TITLE
CircleCI: Fix the Darwin test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,20 @@
 var_0: &global_env
   CACHIX_CACHE: yl
 
-var_1: &install-dependencies
+var_1: &install-nix
+  run:
+    name: Install Nix
+    command: |
+      curl https://nixos.org/nix/install | sh
+
+var_2: &install-dependencies
   run:
     name: Install dependencies
     command: |
+      if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
+        source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+      fi
+
       # install git
       nix-env -f '<nixpkgs>' -iA gitAndTools.git
 
@@ -13,17 +23,25 @@ var_1: &install-dependencies
       readonly nixpkgs="$( nix-build --no-out-link ${nixpkgs_stable} )"
       nix-env -I nixpkgs="${nixpkgs}" -f '<nixpkgs>' -iA cachix
 
-var_2: &enable-cachix
+var_3: &enable-cachix
   run:
     name: Enable cachix
     command: |
+      if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
+        source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+      fi
+
       cachix use "${CACHIX_CACHE}"
 
-var_3: &instantiate-host
+var_4: &instantiate-host
   run:
     name: Instantiate the host
-    working_directory: /go/src/github.com/kalbasit/shabka
+    working_directory: ~/shabka
     command: |
+      if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
+        source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+      fi
+
       readonly shabka_path="$( pwd )"
       readonly nixpkgs_stable="${shabka_path}/external/nixpkgs-stable.nix"
       readonly nixpkgs_unstable="${shabka_path}/external/nixpkgs-unstable.nix"
@@ -54,22 +72,20 @@ jobs:
     macos:
       xcode: "9.0"
 
-    working_directory: /go/src/github.com/kalbasit/shabka
+    working_directory: ~/shabka
 
     environment:
       <<: *global_env
 
-    docker:
-      - image: nixos/nix
-
     steps:
       - checkout
+      - *install-nix
       - *install-dependencies
       - *enable-cachix
       - *instantiate-host
 
   cratos:
-    working_directory: /go/src/github.com/kalbasit/shabka
+    working_directory: ~/shabka
 
     environment:
       <<: *global_env
@@ -84,7 +100,7 @@ jobs:
       - *instantiate-host
 
   hades:
-    working_directory: /go/src/github.com/kalbasit/shabka
+    working_directory: ~/shabka
 
     environment:
       <<: *global_env
@@ -99,7 +115,7 @@ jobs:
       - *instantiate-host
 
   hera:
-    working_directory: /go/src/github.com/kalbasit/shabka
+    working_directory: ~/shabka
 
     environment:
       <<: *global_env
@@ -114,7 +130,7 @@ jobs:
       - *instantiate-host
 
   zeus:
-    working_directory: /go/src/github.com/kalbasit/shabka
+    working_directory: ~/shabka
 
     environment:
       <<: *global_env

--- a/modules/home/software/packages.nix
+++ b/modules/home/software/packages.nix
@@ -3,12 +3,16 @@
 with pkgs;
 
 let
-
-  homeManager = import ../../../external/home-manager.nix {
-    pkgs = (import <nixpkgs> {});
-    inherit (import ../../../util) assertMsg;
-  };
-
+  homeManager =
+    let
+      nixpkgs = import ../../../external/nixpkgs-stable.nix;
+      pkgs = import nixpkgs {
+        config = {};
+        overlays = [];
+      };
+    in import ../../../external/home-manager.nix {
+      inherit (pkgs) fetchpatch runCommand;
+    };
 in {
   home.packages = [
     amazon-ecr-credential-helper
@@ -25,8 +29,6 @@ in {
     go
 
     gotop
-
-    jetbrains.idea-community
 
     jq
 
@@ -63,6 +65,8 @@ in {
     #
     # Linux applications
     #
+
+    jetbrains.idea-community
 
     keybase
 

--- a/modules/home/software/zsh/default.nix
+++ b/modules/home/software/zsh/default.nix
@@ -56,9 +56,6 @@ let
         --subst-var-by jq_bin ${getBin jq}/bin/jq \
         --subst-var-by xsel_bin ${getBin xsel}/bin/xsel
 
-      substituteInPlace $out/register_u2f \
-        --subst-var-by pamu2fcfg_bin ${getBin pam_u2f}/bin/pamu2fcfg
-
       substituteInPlace $out/sapg \
         --subst-var-by apg_bin ${getBin apg}/bin/apg
 
@@ -99,10 +96,13 @@ let
 
       substituteInPlace $out/umount.enc \
         --subst-var-by cryptsetup_bin ${getBin cryptsetup}/bin/cryptsetup
+
+      substituteInPlace $out/register_u2f \
+        --subst-var-by pamu2fcfg_bin ${getBin pam_u2f}/bin/pamu2fcfg
     ''
 
     + lib.optionalString stdenv.isDarwin ''
-      rm -f $out/mkfs.enc $out/mount.enc $out/umount.enc
+      rm -f $out/mkfs.enc $out/mount.enc $out/umount.enc $out/register_u2f
     '';
   };
 


### PR DESCRIPTION
When a CircleCI job has both the `macos` key and the `docker` key, it does
pick `docker` (preference or order, unsure!). That means that I have
been testing in a Linux docker container for the entire time! This change enables true Darwin job on CircleCI.