### PR TITLE
hosts/hades: revert back to the stable channel

### DIFF
--- a/hosts/hades/release
+++ b/hosts/hades/release
@@ -1,1 +1,0 @@
-unstable


### PR DESCRIPTION
GnuPG is not working correctly with YubiKey, I'm getting `No such device
again`. I believe it's the same issue as before where scdaemon attempts
to contact the Broadcom card even though I do have `reader-port Yubico
Yubikey` in `~/.gnupg/scdaemon.conf`.

This partially reverts commit 5dd31dbf801173ce347827ddb061e4914cb58e4c.