### PR TITLE
[External] Fix a bug in the update script, update all external dependencies

### DIFF
--- a/external/home-manager-version.json
+++ b/external/home-manager-version.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/rycee/home-manager/archive/79731e6ab4d41ce4569fe6b60623a590675288af.tar.gz",
-  "sha256": "0myzxzkp5brw77k5kqn6nwwzka8cspvqchbjrg26j509qh0xkrmd",
-  "rev": "79731e6ab4d41ce4569fe6b60623a590675288af"
+  "url": "https://github.com/rycee/home-manager/archive/799a90ecfaa717bc617ffad19383d1cddd4c99ad.tar.gz",
+  "sha256": "1j3q8bkggjkniiy3x9fwxd9n196pmw11s78h0g40p36mq0qz5wm9",
+  "rev": "799a90ecfaa717bc617ffad19383d1cddd4c99ad"
 }

--- a/external/nixpkgs-stable-version.json
+++ b/external/nixpkgs-stable-version.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/NixOS/nixpkgs-channels/archive/5225d4bf0193b51cfb1a200faa4ae50958f98c62.tar.gz",
-  "sha256": "1qj5r2l24s567rdbamhqal1d96fqm4i5aih20sag59dr91qb9lki",
-  "rev": "5225d4bf0193b51cfb1a200faa4ae50958f98c62"
+  "url": "https://github.com/NixOS/nixpkgs-channels/archive/9bd45dddf8171e2fd4288d684f4f70a2025ded19.tar.gz",
+  "sha256": "1idrxrymwqfsfysav3yl8lya1jhgg8xzgq9hy7dpdd63770vn8c1",
+  "rev": "9bd45dddf8171e2fd4288d684f4f70a2025ded19"
 }

--- a/external/nixpkgs-unstable-version.json
+++ b/external/nixpkgs-unstable-version.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/NixOS/nixpkgs-channels/archive/929cc78363e6878e044556bd291382eab37bcbed.tar.gz",
-  "sha256": "1ghzjk6fq8f2aimp23p45awnfzlcqc20sf7p1xp98myis1sqniwb",
-  "rev": "929cc78363e6878e044556bd291382eab37bcbed"
+  "url": "https://github.com/NixOS/nixpkgs-channels/archive/36f316007494c388df1fec434c1e658542e3c3cc.tar.gz",
+  "sha256": "1w1dg9ankgi59r2mh0jilccz5c4gv30a6q1k6kv2sn8vfjazwp9k",
+  "rev": "36f316007494c388df1fec434c1e658542e3c3cc"
 }

--- a/external/nur-version.json
+++ b/external/nur-version.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://github.com/nix-community/NUR/archive/11937cf90187b7cb1eb43b02c8fc3a45cb16fd8b.tar.gz",
-  "sha256": "0q485pc2d7m1jl72rd9b5jliq910q03sghg2vwxx5xg3wb8i21sc",
-  "rev": "11937cf90187b7cb1eb43b02c8fc3a45cb16fd8b"
+  "url": "https://github.com/nix-community/NUR/archive/6328222b3a68f575b53268888217c3c27125d0f8.tar.gz",
+  "sha256": "0yl1qzgp912iqvifcl2gkl6z160nbf2aa9zgzdp8abnmrg50vq7c",
+  "rev": "6328222b3a68f575b53268888217c3c27125d0f8"
 }


### PR DESCRIPTION
In addition to the updated externals below, this change fixes an issue with the update script not operating correctly when adding a new external dependency.

- NUR: Compare changes at https://github.com/nix-community/NUR/compare/11937cf90187b7cb1eb43b02c8fc3a45cb16fd8b...6328222b3a68f575b53268888217c3c27125d0f8
- nixpkgs-unstable: Compare changes at https://github.com/NixOS/nixpkgs-channels/compare/929cc78363e6878e044556bd291382eab37bcbed...36f316007494c388df1fec434c1e658542e3c3cc
- nixpkgs-stable: Compare changes at https://github.com/NixOS/nixpkgs-channels/compare/5225d4bf0193b51cfb1a200faa4ae50958f98c62...9bd45dddf8171e2fd4288d684f4f70a2025ded19
- home-manager: Compare changes at https://github.com/rycee/home-manager/compare/79731e6ab4d41ce4569fe6b60623a590675288af...799a90ecfaa717bc617ffad19383d1cddd4c99ad