### PR TITLE
[Home] Fix NeoVim starting in a bad graphic state

### DIFF
--- a/modules/home/software/zsh/default.nix
+++ b/modules/home/software/zsh/default.nix
@@ -143,7 +143,7 @@ in {
         # TODO: move this to the swm package
         s = "swm tmux switch-client";
         sb = "swm --story base tmux switch-client";
-        vim_ready = ""; # TODO: run direnv here
+        vim_ready = "sleep 1"; # TODO: run direnv here
 
         # TODO: move to docker-config, how to tell ZSH to import them?
         remove_created_containers = "docker rm -v \$(docker ps -a -q -f status=created)";

--- a/modules/home/software/zsh/default.nix
+++ b/modules/home/software/zsh/default.nix
@@ -143,7 +143,7 @@ in {
         # TODO: move this to the swm package
         s = "swm tmux switch-client";
         sb = "swm --story base tmux switch-client";
-        vim_ready = "sleep 1"; # TODO: run direnv here
+        vim_ready = "sleep 1";
 
         # TODO: move to docker-config, how to tell ZSH to import them?
         remove_created_containers = "docker rm -v \$(docker ps -a -q -f status=created)";


### PR DESCRIPTION
In d3b1abe39d94545c04e7003202abb98d8000a477 or 99922579fc5389e456ca2644dedd93dc53fa59e8 NeoVim started booting in a broken state after SWM starts it up a TMux session. It seems for some reason that it's breaking because it's starting too fast. This change sets `vim_ready` to `sleep 1` so NeoVim gets delayed a second after the TMux session has started.