### PR TITLE
[NeoVim] Improve the multiple cursor compatibility with deoplete

### DIFF
--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -299,13 +299,20 @@ let g:multi_cursor_quit_key            = '<Esc>'
 
 " Prevent conflict with deoplete
 " Called once right before you start selecting multiple cursors
-function! Multiple_cursors_before()
-  call deoplete#disable()
-endfunction
+func! Multiple_cursors_before()
+  if deoplete#is_enabled()
+    call deoplete#disable()
+    let g:deoplete_is_enable_before_multi_cursors = 1
+  else
+    let g:deoplete_is_enable_before_multi_cursors = 0
+  endif
+endfunc
 " Called once only when the multiple selection is canceled (default <Esc>)
-function! Multiple_cursors_after()
-  call deoplete#enable()
-endfunction
+func! Multiple_cursors_after()
+  if g:deoplete_is_enable_before_multi_cursors
+    call deoplete#enable()
+  endif
+endfunc
 
 "" }}}
 "" Polyglot{{{


### PR DESCRIPTION
When entering multiple cursors, check if deoplete is enabled before
attempting to disable it. When the multiple cursors mode is ending,
re-enable deoplete only if it was found enabled before.

fixes #85 
improves #178 