### PR TITLE
[NeoVim] Disable automatic Markdown folding

### DIFF
--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -323,6 +323,7 @@ let g:polyglot_disabled = [
   \   'csv',
   \   'go',
   \   'latex',
+  \   'markdown',
   \   'ruby',
   \   'terraform',
   \   'typescript',

--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -405,6 +405,7 @@ augroup END
 "" Terraform{{{
 ""
 
+let g:terraform_align=1
 let g:terraform_fmt_on_save = 1
 
 ""}}}

--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -272,6 +272,11 @@ let g:go_highlight_build_constraints = 1
 "" Gundo{{{
 nmap <Leader>go :GundoToggle<CR>
 "" }}}
+"" Markdown{{{
+
+let g:vim_markdown_folding_disabled = 1
+
+"" }}}
 "" Markdown preview{{{
 
 if executable('grip')

--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -277,15 +277,6 @@ nmap <Leader>go :GundoToggle<CR>
 let g:vim_markdown_folding_disabled = 1
 
 "" }}}
-"" Markdown preview{{{
-
-if executable('grip')
-  let g:vim_markdown_preview_github=1
-endif
-
-let g:vim_markdown_preview_use_xdg_open=1
-
-"" }}}
 "" Multiple cursors{{{
 
 let g:multi_cursor_use_default_mapping=0

--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -167,10 +167,6 @@ if has("autocmd")
   " Set the Ruby filetype for a number of common Ruby files without .rb
   au BufRead,BufNewFile {Gemfile,Rakefile,Vagrantfile,Thorfile,Procfile,Guardfile,config.ru,*.rake} set ft=ruby
 
-  " Make sure all mardown files have the correct filetype set and setup wrapping
-  au BufRead,BufNewFile *.{md,markdown,mdown,mkd,mkdn,txt} set ft=markdown
-  au FileType markdown setlocal wrap linebreak textwidth=72 nolist
-
   " make Python follow PEP8 for whitespace.
   " http://www.python.org/dev/peps/pep-0008/
   au FileType python setlocal tabstop=4 shiftwidth=4 expandtab

--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -318,7 +318,14 @@ endfunc
 "" Polyglot{{{
 ""
 
-let g:polyglot_disabled = ['csv', 'go', 'latex', 'ruby', 'terraform', 'typescript']
+let g:polyglot_disabled = [
+  \   'csv',
+  \   'go',
+  \   'latex',
+  \   'ruby',
+  \   'terraform',
+  \   'typescript',
+  \ ]
 
 " }}}
 "" Surround{{{

--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -567,24 +567,6 @@ function! ExtractVariable()
   normal! $p
 endfunction
 
-" TODO: candidate for removal
-function! ShowRoutes()
-  " Requires 'scratch' plugin
-  :topleft 100 :split __Routes__
-  " Make sure Vim doesn't write __Routes__ as a file
-  :set buftype=nofile
-  " Delete everything
-  :normal 1GdG
-  " Put routes output in buffer
-  :0r! rake -s routes
-  " Size window to number of lines (1 plus rake output length)
-  :exec ":normal " . line("$") . _ "
-  " Move cursor to bottom
-  :normal 1GG
-  " Delete empty trailing line
-  :normal dd
-endfunction
-
 function! InlineVariable()
   " Copy the variable under the cursor into the 'a' register
   :let l:tmp_a = @a
@@ -608,6 +590,7 @@ function! InlineVariable()
   :let @b = l:tmp_b
 endfunction
 
+" TODO: Extract this logic into an open-source module
 function! OpenTestAlternate(position)
   let current_file = expand("%")
   let new_file = current_file


### PR DESCRIPTION
In addition to disabling automatic markdown folding, this change disables Polyglot Markdown support and an extraneous BufferEnter command for Markdown. It also enables alignment for Terraform files, this option is described as `Allow vim-terraform to override your .vimrc indentation syntax for matching files`.

Cleanup:
- Options for missing `Markdown Preview` plugins are now removed.
- Unused function `ShowRoutes` is now removed.

closes #186 