### PR TITLE
[Shell] register_u2f: make sure there is a newline at the end

### DIFF
--- a/modules/home/software/zsh/plugins/functions/register_u2f
+++ b/modules/home/software/zsh/plugins/functions/register_u2f
@@ -8,5 +8,5 @@ function register_u2f() {
 	# https://github.com/NixOS/nixpkgs/pull/11886 is merged!
 	local u2f_keys="${HOME}/.config/Yubico/u2f_keys"
 	mkdir -p "$( dirname "${u2f_keys}" )"
-	@pamu2fcfg_bin@ >> "${u2f_keys}"
+	(@pamu2fcfg_bin@; echo) >> "${u2f_keys}"
 }


### PR DESCRIPTION
Registering U2F devices are one line per U2F. The current version is not
adding a newline at the end of the entry, and in turns adding a new U2F
device gets appended to the entry of the previous U2F key effectively
breaking both keys.