### PR TITLE
[nixos] Set the NixOS label correctly set from within a Git worktree

### DIFF
--- a/external/default.nix
+++ b/external/default.nix
@@ -22,6 +22,7 @@ let
 
 in {
   home-manager = import ./home-manager { inherit mkExternal; };
+  iohk-nix = import ./iohk-nix { inherit mkExternal; };
   kalbasit = import ./kalbasit { inherit mkExternal; };
   nix-darwin = import ./nix-darwin { inherit mkExternal; };
   nixos-hardware = import ./nixos-hardware { inherit mkExternal; };

--- a/external/iohk-nix/default.nix
+++ b/external/iohk-nix/default.nix
@@ -1,0 +1,20 @@
+{ mkExternal }:
+
+let
+  pinnedVersion = builtins.fromJSON (builtins.readFile ./version.json);
+
+  src = builtins.fetchTarball {
+    inherit (pinnedVersion) url sha256;
+  };
+
+  patches = [];
+
+  patched = mkExternal {
+    inherit src patches;
+
+    name = "iohk-nix";
+    revision = pinnedVersion.rev;
+  };
+in {
+  path = patched;
+}

--- a/external/iohk-nix/update.sh
+++ b/external/iohk-nix/update.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+readonly here="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+readonly shabka_path="$(cd "${here}"/../../ && pwd)"
+
+exec "${shabka_path}/scripts/update-external.sh" input-output-hk iohk-nix master "${here}/version.json"

--- a/external/iohk-nix/version.json
+++ b/external/iohk-nix/version.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/input-output-hk/iohk-nix/archive/8a5bc149b4d4cfa8704be62cf1b8755c33e8ec4d.tar.gz",
+  "sha256": "0v1x8zwyiwxhjhfrws2mvick7j1qvfj111chb4c4ixjinlgby0nl",
+  "rev": "8a5bc149b4d4cfa8704be62cf1b8755c33e8ec4d"
+}

--- a/modules/nixos/general/version.nix
+++ b/modules/nixos/general/version.nix
@@ -24,14 +24,16 @@
 # }
 
 let
+  shabka = import <shabka> { };
+
+  iohk-nix = import shabka.external.iohk-nix.path {};
+
   git_dir = ../../../.git;
 
   # TODO: This is hardcoded! It should instead point to whatever value pkgs.path is
   pinnedNixpkgsVersion = builtins.fromJSON (builtins.readFile ../../../external/nixpkgs/18.09/version.json);
 
-  label = "nixos_${config.system.nixos.release}-${builtins.substring 0 7 pinnedNixpkgsVersion.rev}-shabka_" + (if lib.pathIsDirectory git_dir then
-    "${builtins.substring 0 7 (lib.commitIdFromGitRepo git_dir)}"
-  else "story");
+  label = "nixos_${config.system.nixos.release}-${builtins.substring 0 7 pinnedNixpkgsVersion.rev}-shabka_${builtins.substring 0 7 (iohk-nix.commitIdFromGitRepo git_dir)}";
 
 in {
   # git is required to compute the label within lib.commitIdFromGitRepo.


### PR DESCRIPTION
Use <iohk-nix>.commitIdFromGitRepo to correctly compute the Git revision of shabka from a Git worktree. Where <iohk-nix> is located at https://github.com/input-output-hk/iohk-nix.