### PR TITLE
Fix nix.buildMachines on all hosts when my secrets are not present

### DIFF
--- a/hosts/athena/configuration.nix
+++ b/hosts/athena/configuration.nix
@@ -7,33 +7,6 @@
 
   networking.hostName = "athena";
 
-  nix.buildMachines = [
-    (optionalAttrs (builtins.pathExists /Users/yl/private/network-secrets/shabka/hosts/demeter/id_rsa) {
-      hostName = fileContents /Users/yl/private/network-secrets/shabka/hosts/demeter/hostname;
-      sshUser = "builder";
-      sshKey = "/Users/yl/private/network-secrets/shabka/hosts/demeter/id_rsa";
-      system = "x86_64-linux";
-      maxJobs = 8;
-      speedFactor = 2;
-      supportedFeatures = [ ];
-      mandatoryFeatures = [ ];
-    })
-
-    (optionalAttrs (builtins.pathExists /Users/yl/private/network-secrets/shabka/hosts/zeus/id_rsa) {
-      hostName = "zeus.home.nasreddine.com";
-      sshUser = "builder";
-      sshKey = "/Users/yl/private/network-secrets/shabka/hosts/zeus/id_rsa";
-      system = "x86_64-linux";
-      maxJobs = 8;
-      speedFactor = 2;
-      supportedFeatures = [ ];
-      mandatoryFeatures = [ ];
-    })
-  ];
-  nix.extraOptions = ''
-    builders-use-substitutes = true
-  '';
-
   time.timeZone = "America/Los_Angeles";
 
   mine.gnupg.enable = true;

--- a/hosts/cratos/configuration.nix
+++ b/hosts/cratos/configuration.nix
@@ -40,8 +40,12 @@ in {
 
   networking.hostName = "cratos";
 
-  nix.buildMachines = [
-    (optionalAttrs (builtins.pathExists /yl/private/network-secrets/shabka/hosts/demeter/id_rsa) {
+  nix.extraOptions = ''
+    builders-use-substitutes = true
+  '';
+
+  nix.buildMachines =
+    (optional (builtins.pathExists /yl/private/network-secrets/shabka/hosts/demeter/id_rsa) (singleton {
       hostName = fileContents /yl/private/network-secrets/shabka/hosts/demeter/hostname;
       sshUser = "builder";
       sshKey = "/yl/private/network-secrets/shabka/hosts/demeter/id_rsa";
@@ -50,9 +54,8 @@ in {
       speedFactor = 2;
       supportedFeatures = [ ];
       mandatoryFeatures = [ ];
-    })
-
-    (optionalAttrs (builtins.pathExists /yl/private/network-secrets/shabka/hosts/zeus/id_rsa) {
+    }))
+    ++ (optional (builtins.pathExists /yl/private/network-secrets/shabka/hosts/zeus/id_rsa) (singleton {
       hostName = "zeus.home.nasreddine.com";
       sshUser = "builder";
       sshKey = "/yl/private/network-secrets/shabka/hosts/zeus/id_rsa";
@@ -61,11 +64,7 @@ in {
       speedFactor = 2;
       supportedFeatures = [ ];
       mandatoryFeatures = [ ];
-    })
-  ];
-  nix.extraOptions = ''
-    builders-use-substitutes = true
-  '';
+    }));
 
   mine.hardware.intel_backlight.enable = true;
   mine.printing.enable = true;

--- a/hosts/hades/configuration.nix
+++ b/hosts/hades/configuration.nix
@@ -42,8 +42,12 @@ in {
 
   networking.hostName = "hades";
 
-  nix.buildMachines = [
-    (optionalAttrs (builtins.pathExists /yl/private/network-secrets/shabka/hosts/demeter/id_rsa) {
+  nix.extraOptions = ''
+    builders-use-substitutes = true
+  '';
+
+  nix.buildMachines =
+    (optional (builtins.pathExists /yl/private/network-secrets/shabka/hosts/demeter/id_rsa) (singleton {
       hostName = fileContents /yl/private/network-secrets/shabka/hosts/demeter/hostname;
       sshUser = "builder";
       sshKey = "/yl/private/network-secrets/shabka/hosts/demeter/id_rsa";
@@ -52,9 +56,8 @@ in {
       speedFactor = 2;
       supportedFeatures = [ ];
       mandatoryFeatures = [ ];
-    })
-
-    (optionalAttrs (builtins.pathExists /yl/private/network-secrets/shabka/hosts/zeus/id_rsa) {
+    }))
+    ++ (optional (builtins.pathExists /yl/private/network-secrets/shabka/hosts/zeus/id_rsa) (singleton {
       hostName = "zeus.home.nasreddine.com";
       sshUser = "builder";
       sshKey = "/yl/private/network-secrets/shabka/hosts/zeus/id_rsa";
@@ -63,11 +66,7 @@ in {
       speedFactor = 2;
       supportedFeatures = [ ];
       mandatoryFeatures = [ ];
-    })
-  ];
-  nix.extraOptions = ''
-    builders-use-substitutes = true
-  '';
+    }));
 
   mine.hardware.intel_backlight.enable = true;
   mine.printing.enable = true;

--- a/hosts/hera/configuration.nix
+++ b/hosts/hera/configuration.nix
@@ -42,8 +42,12 @@ in {
 
   networking.hostName = "hera";
 
-  nix.buildMachines = [
-    (optionalAttrs (builtins.pathExists /yl/private/network-secrets/shabka/hosts/demeter/id_rsa) {
+  nix.extraOptions = ''
+    builders-use-substitutes = true
+  '';
+
+  nix.buildMachines =
+    (optional (builtins.pathExists /yl/private/network-secrets/shabka/hosts/demeter/id_rsa) (singleton {
       hostName = fileContents /yl/private/network-secrets/shabka/hosts/demeter/hostname;
       sshUser = "builder";
       sshKey = "/yl/private/network-secrets/shabka/hosts/demeter/id_rsa";
@@ -52,9 +56,8 @@ in {
       speedFactor = 2;
       supportedFeatures = [ ];
       mandatoryFeatures = [ ];
-    })
-
-    (optionalAttrs (builtins.pathExists /yl/private/network-secrets/shabka/hosts/zeus/id_rsa) {
+    }))
+    ++ (optional (builtins.pathExists /yl/private/network-secrets/shabka/hosts/zeus/id_rsa) (singleton {
       hostName = "zeus.home.nasreddine.com";
       sshUser = "builder";
       sshKey = "/yl/private/network-secrets/shabka/hosts/zeus/id_rsa";
@@ -63,11 +66,7 @@ in {
       speedFactor = 2;
       supportedFeatures = [ ];
       mandatoryFeatures = [ ];
-    })
-  ];
-  nix.extraOptions = ''
-    builders-use-substitutes = true
-  '';
+    }));
 
   mine.hardware.intel_backlight.enable = true;
   mine.printing.enable = true;

--- a/hosts/poseidon/configuration.nix
+++ b/hosts/poseidon/configuration.nix
@@ -7,33 +7,6 @@
 
   networking.hostName = "poseidon";
 
-  nix.buildMachines = [
-    (optionalAttrs (builtins.pathExists /Users/yl/private/network-secrets/shabka/hosts/demeter/id_rsa) {
-      hostName = fileContents /Users/yl/private/network-secrets/shabka/hosts/demeter/hostname;
-      sshUser = "builder";
-      sshKey = "/Users/yl/private/network-secrets/shabka/hosts/demeter/id_rsa";
-      system = "x86_64-linux";
-      maxJobs = 8;
-      speedFactor = 2;
-      supportedFeatures = [ ];
-      mandatoryFeatures = [ ];
-    })
-
-    (optionalAttrs (builtins.pathExists /Users/yl/private/network-secrets/shabka/hosts/zeus/id_rsa) {
-      hostName = "zeus.home.nasreddine.com";
-      sshUser = "builder";
-      sshKey = "/Users/yl/private/network-secrets/shabka/hosts/zeus/id_rsa";
-      system = "x86_64-linux";
-      maxJobs = 8;
-      speedFactor = 2;
-      supportedFeatures = [ ];
-      mandatoryFeatures = [ ];
-    })
-  ];
-  nix.extraOptions = ''
-    builders-use-substitutes = true
-  '';
-
   time.timeZone = "America/Los_Angeles";
 
   # mine.gnupg.enable = true;


### PR DESCRIPTION
The absence of the secrets was causing `nix.buildMachines` to be set to `[ {} {} ]`. This value is invalid as each item in the list was missing the hostname.

This change also removes all build machines from my Darwin configurations because my build machines do not support Darwin and thus useless.

fixes #211 