### PR TITLE
[Git] Make user's name, email and PGP key configurable

### DIFF
--- a/modules/home/software/git/default.nix
+++ b/modules/home/software/git/default.nix
@@ -9,27 +9,25 @@ in {
   options = {
 
     mine.git = {
-
       enable = mkEnableOption "git";
 
-      userName = mkOption{
+      userName = mkOption {
         type = types.str;
         default = "Wael M. Nasreddine";
         description = "git user name";
       };
 
-      userEmail = {
+      userEmail = mkOption {
         type = types.str;
         default = "wael.nasreddine@gmail.com";
         description = "git user email";
       };
 
-      gpgSigningKey = mkOption{
+      gpgSigningKey = mkOption {
         type = types.str;
         default = "me@yl.codes";
         description = "git PGP signing key";
       };
-
     };
   };
 

--- a/modules/home/software/git/default.nix
+++ b/modules/home/software/git/default.nix
@@ -1,14 +1,39 @@
-# TODO(high): the gpg key must be configurable
 { config, pkgs, lib, ... }:
 
 with lib;
 
 let
   shabka = import <shabka> { };
+  cfg = config.mine.git;
 in {
-  options.mine.git.enable = mkEnableOption "git";
+  options = {
 
-  config = mkIf config.mine.git.enable {
+    mine.git = {
+
+      enable = mkEnableOption "git";
+
+      userName = mkOption{
+        type = types.str;
+        default = "Wael M. Nasreddine";
+        description = "git user name";
+      };
+
+      userEmail = {
+        type = types.str;
+        default = "wael.nasreddine@gmail.com";
+        description = "git user email";
+      };
+
+      gpgSigningKey = mkOption{
+        type = types.str;
+        default = "me@yl.codes";
+        description = "git PGP signing key";
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
     home.packages = with pkgs; [
       (gitAndTools.git-appraise or shabka.external.nixpkgs.release-unstable.gitAndTools.git-appraise)
       gitAndTools.hub
@@ -18,9 +43,9 @@ in {
     programs.git = {
       enable = true;
 
-      userName = "Wael M. Nasreddine";
+      userName = cfg.userName;
 
-      userEmail = "wael.nasreddine@gmail.com";
+      userEmail = cfg.userEmail;
 
       aliases = {
         aa             = "add --all .";
@@ -270,7 +295,7 @@ in {
       ];
 
       signing = {
-        key = "me@yl.codes";
+        key = cfg.gpgSigningKey;
         signByDefault = true;
       };
     };


### PR DESCRIPTION
Resolves the TODO in `modules/home/software/git/default.nix`