### PR TITLE
[Tmux] Fix the styles for >= 2.9

### DIFF
--- a/modules/home/software/tmux.nix
+++ b/modules/home/software/tmux.nix
@@ -48,14 +48,9 @@ let
     set-window-option -g window-status-bell-style fg=colour235,bg=colour167 #bg, red
 
     ## Theme settings mixed with colors (unfortunately, but there is no cleaner way)
-    set-option -g status-attr "none"
     set-option -g status-justify "left"
-    set-option -g status-left-attr "none"
     set-option -g status-left-length "80"
-    set-option -g status-right-attr "none"
     set-option -g status-right-length "80"
-    set-window-option -g window-status-activity-attr "none"
-    set-window-option -g window-status-attr "none"
     set-window-option -g window-status-separator ""
 
     set-option -g status-left "#[fg=colour248, bg=colour241] #S #[fg=colour241, bg=colour237, nobold, noitalics, nounderscore]"
@@ -66,24 +61,26 @@ let
   ''
   + (if versionAtLeast (builtins.parseDrvName pkgs.tmux.name).version "2.9" then ''
       # default statusbar colors
-      set-option -g status-status bg=colour237,fg=colour223
+      set-option -g status-style bg=colour237,fg=colour223,none
+      set-option -g status-left-style none
+      set-option -g status-right-style none
 
       # default window title colors
-      set-window-option -g window-status-status bg=colour214,fg=colour237
+      set-window-option -g window-status-style bg=colour214,fg=colour237,none
 
-      set-window-option -g window-status-activity-status bg=colour237,fg=colour248
+      set-window-option -g window-status-activity-style bg=colour237,fg=colour248,none
 
       # active window title colors
-      set-window-option -g window-status-current-status bg=default,fg=colour237
+      set-window-option -g window-status-current-style bg=default,fg=colour237
 
       # pane border
-      set-option -g pane-active-border-status fg=colour250,fg=colour237
+      set-option -g pane-active-border-style fg=colour250,fg=colour237
 
       # message infos
-      set-option -g message-status bg=colour239,fg=colour223
+      set-option -g message-style bg=colour239,fg=colour223
 
       # writting commands inactive
-      set-option -g message-command-status bg=colour239fg=colour223
+      set-option -g message-command-style bg=colour239,fg=colour223
     '' else ''
       # default statusbar colors
       set-option -g status-bg colour237 #bg1
@@ -111,6 +108,12 @@ let
       # writting commands inactive
       set-option -g message-command-bg colour239 #fg3
       set-option -g message-command-fg colour223 #bg1
+
+      set-option -g status-attr "none"
+      set-option -g status-left-attr "none"
+      set-option -g status-right-attr "none"
+      set-window-option -g window-status-activity-attr "none"
+      set-window-option -g window-status-attr "none"
     '');
 
 

--- a/modules/home/software/tmux.nix
+++ b/modules/home/software/tmux.nix
@@ -17,47 +17,26 @@ let
   seoul256Color = ''
     set-option -g status-justify left
     set-option -g status-left-length 16
-    set-option -g status-bg colour237
     set-option -g status-interval 60
-
-    set-option -g pane-active-border-fg colour215
-    set-option -g pane-border-fg colour185
 
     set-option -g status-left '#[bg=colour72] #[bg=colour237] #[bg=colour236] #{prefix_highlight} #[bg=colour235]#[fg=colour185] #h #[bg=colour236] '
     set-option -g status-right '#[bg=colour236] #[bg=colour237]#[fg=colour185] #[bg=colour235] #(date "+%a %b %d %H:%M") #[bg=colour236] #[bg=colour237] #[bg=colour72] '
 
     set-window-option -g window-status-format '#[bg=colour238]#[fg=colour107] #I #[bg=colour239]#[fg=colour110] #[bg=colour240]#W#[bg=colour239]#[fg=colour195]#F#[bg=colour238] '
     set-window-option -g window-status-current-format '#[bg=colour236]#[fg=colour215] #I #[bg=colour235]#[fg=colour167] #[bg=colour234]#W#[bg=colour235]#[fg=colour195]#F#[bg=colour236] '
-  '';
+  ''
+  + (if versionAtLeast (builtins.parseDrvName pkgs.tmux.name).version "2.9" then ''
+      set-option -g status-style bg=colour237
+      set-option -g pane-active-border-style fg=colour215
+      set-option -g pane-border-style fg=colour185
+    '' else ''
+      set-option -g status-bg colour237
+      set-option -g pane-active-border-fg colour215
+      set-option -g pane-border-fg colour185
+
+    '');
 
   gruvBox256Color = ''
-    # default statusbar colors
-    set-option -g status-bg colour237 #bg1
-    set-option -g status-fg colour223 #fg1
-
-    # default window title colors
-    set-window-option -g window-status-bg colour214 #yellow
-    set-window-option -g window-status-fg colour237 #bg1
-
-    set-window-option -g window-status-activity-bg colour237 #bg1
-    set-window-option -g window-status-activity-fg colour248 #fg3
-
-    # active window title colors
-    set-window-option -g window-status-current-bg default
-    set-window-option -g window-status-current-fg colour237 #bg1
-
-    # pane border
-    set-option -g pane-active-border-fg colour250 #fg2
-    set-option -g pane-border-fg colour237 #bg1
-
-    # message infos
-    set-option -g message-bg colour239 #bg2
-    set-option -g message-fg colour223 #fg1
-
-    # writting commands inactive
-    set-option -g message-command-bg colour239 #fg3
-    set-option -g message-command-fg colour223 #bg1
-
     # pane number display
     set-option -g display-panes-active-colour colour250 #fg2
     set-option -g display-panes-colour colour237 #bg1
@@ -84,7 +63,56 @@ let
 
     set-window-option -g window-status-current-format "#[fg=colour239, bg=colour248, :nobold, noitalics, nounderscore]#[fg=colour239, bg=colour214] #I #[fg=colour239, bg=colour214, bold] #W #[fg=colour214, bg=colour237, nobold, noitalics, nounderscore]"
     set-window-option -g window-status-format "#[fg=colour237,bg=colour239,noitalics]#[fg=colour223,bg=colour239] #I #[fg=colour223, bg=colour239] #W #[fg=colour239, bg=colour237, noitalics]"
-  '';
+  ''
+  + (if versionAtLeast (builtins.parseDrvName pkgs.tmux.name).version "2.9" then ''
+      # default statusbar colors
+      set-option -g status-status bg=colour237,fg=colour223
+
+      # default window title colors
+      set-window-option -g window-status-status bg=colour214,fg=colour237
+
+      set-window-option -g window-status-activity-status bg=colour237,fg=colour248
+
+      # active window title colors
+      set-window-option -g window-status-current-status bg=default,fg=colour237
+
+      # pane border
+      set-option -g pane-active-border-status fg=colour250,fg=colour237
+
+      # message infos
+      set-option -g message-status bg=colour239,fg=colour223
+
+      # writting commands inactive
+      set-option -g message-command-status bg=colour239fg=colour223
+    '' else ''
+      # default statusbar colors
+      set-option -g status-bg colour237 #bg1
+      set-option -g status-fg colour223 #fg1
+
+      # default window title colors
+      set-window-option -g window-status-bg colour214 #yellow
+      set-window-option -g window-status-fg colour237 #bg1
+
+      set-window-option -g window-status-activity-bg colour237 #bg1
+      set-window-option -g window-status-activity-fg colour248 #fg3
+
+      # active window title colors
+      set-window-option -g window-status-current-bg default
+      set-window-option -g window-status-current-fg colour237 #bg1
+
+      # pane border
+      set-option -g pane-active-border-fg colour250 #fg2
+      set-option -g pane-border-fg colour237 #bg1
+
+      # message infos
+      set-option -g message-bg colour239 #bg2
+      set-option -g message-fg colour223 #fg1
+
+      # writting commands inactive
+      set-option -g message-command-bg colour239 #fg3
+      set-option -g message-command-fg colour223 #bg1
+    '');
+
 
   tmuxVimAwarness = ''
     # Smart pane switching with awareness of Vim splits.


### PR DESCRIPTION
This change fixes the TMux configuration for new TMux 2.9. The format of the new styling is described in the [manual](https://man.openbsd.org/tmux.1#STYLES).

closes #217