### PR TITLE
[home/TMux] enable secureSocket on Linux only

### DIFF
--- a/modules/home/software/tmux.nix
+++ b/modules/home/software/tmux.nix
@@ -214,6 +214,7 @@ in {
       escapeTime = 0;
       historyLimit = 10000;
       keyMode = "vi";
+      secureSocket = pkgs.stdenv.isLinux;
       shortcut = "t";
 
       extraConfig = ''


### PR DESCRIPTION
TMux is currently broken on Darwin because of secureSocket. It returns an error: `error creating /run/user/$(id -u)/tmux-501`.