### PR TITLE
scripts/diff-host.sh: diff a host against two revisions

### DIFF
--- a/scripts/build-host.sh
+++ b/scripts/build-host.sh
@@ -2,11 +2,10 @@
 
 set -euo pipefail
 
-readonly shabka_path="$(cd $(dirname "${BASH_SOURCE[0]}")/../ && pwd)"
 readonly current_uname="$(uname -s | tr -d '\n')"
 
 build_host() {
-    local host="${1}"
+    local host="${1}"; shift
     local release
 
     if ! [[ -f "${shabka_path}/hosts/${host}/.uname" ]]; then
@@ -33,13 +32,21 @@ build_host() {
     echo ">>> Building the host ${host}"
     echo -e "\tNIX_PATH=${nix_path}"
     NIX_PATH="${nix_path}" \
-        nix-build --option builders '' "${shabka_path}/hosts/${host}" -A system
+        nix-build --option builders '' "${shabka_path}/hosts/${host}" -A system "${@}"
 }
 
 
-if [[ "${#}" -ne 1 ]]; then
+if [[ "${#}" -lt 1 ]]; then
     >&2 echo "ERR: Must give a host to build"
     exit 1
 fi
 
-build_host "${1}"
+if [[ "${1}" == "--shabka-path" ]]; then
+    readonly shabka_path="${2}"
+    shift 2
+else
+    readonly shabka_path="$(cd $(dirname "${BASH_SOURCE[0]}")/../ && pwd)"
+fi
+
+
+build_host "${@}"

--- a/scripts/build-host.sh
+++ b/scripts/build-host.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 readonly current_uname="$(uname -s | tr -d '\n')"
+readonly shabka_path="$(cd $(dirname "${BASH_SOURCE[0]}")/../ && pwd)"
 
 build_host() {
     local host="${1}"; shift
@@ -40,13 +41,5 @@ if [[ "${#}" -lt 1 ]]; then
     >&2 echo "ERR: Must give a host to build"
     exit 1
 fi
-
-if [[ "${1}" == "--shabka-path" ]]; then
-    readonly shabka_path="${2}"
-    shift 2
-else
-    readonly shabka_path="$(cd $(dirname "${BASH_SOURCE[0]}")/../ && pwd)"
-fi
-
 
 build_host "${@}"

--- a/scripts/diff-host.sh
+++ b/scripts/diff-host.sh
@@ -34,17 +34,11 @@ trap "rm -rf ${wd}" EXIT
 
 cd "${wd}"
 
-(
-    git clone "${shabka_path}" base
-    cd base
-    git checkout "${base_rev}"
-)
+git clone "${shabka_path}" base
+git -C "${wd}/base" checkout "${base_rev}"
 
-(
-    git clone "${shabka_path}" target
-    cd target
-    git checkout "${target_rev}"
-)
+git clone "${shabka_path}" target
+git -C "${wd}/target" checkout "${target_rev}"
 
 "${wd}/base/scripts/build-host.sh" "${host}" --out-link base-result
 "${wd}/target/scripts/build-host.sh" "${host}" --out-link target-result

--- a/scripts/diff-host.sh
+++ b/scripts/diff-host.sh
@@ -46,15 +46,7 @@ cd "${wd}"
     git checkout "${target_rev}"
 )
 
-# build the base
-if ! "${wd}/base/scripts/build-host.sh" "${host}" --out-link base-result; then
-    # probably failed because the base version does not support extra
-    # arguments, in this case `--out-link base-result`. Call it using the
-    # script we already have in this branch now.
-    "${shabka_path}/scripts/build-host.sh" --shabka-path "${wd}/base" "${host}" --out-link base-result
-fi
-
-# build the target
+"${wd}/base/scripts/build-host.sh" "${host}" --out-link base-result
 "${wd}/target/scripts/build-host.sh" "${host}" --out-link target-result
 
 nix-diff "$(nix-store -q --deriver base-result)" "$(nix-store -q --deriver target-result)"

--- a/scripts/diff-host.sh
+++ b/scripts/diff-host.sh
@@ -1,0 +1,52 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-diff
+
+set -euo pipefail
+
+readonly shabka_path="$(cd $(dirname "${BASH_SOURCE[0]}")/../ && pwd)"
+
+usage() {
+    >&2 echo "USAGE: $0 <host> <base-rev> [target-rev]"
+    >&2 echo "If no target-rev is given, HEAD will be used"
+}
+
+if [[ "${#}" -gt 0 ]] && [[ "${1}" = "-h" ]] && [[ "${1}" = "--help" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ "${#}" -lt 2 ]]; then
+    usage
+    exit 1
+fi
+
+readonly host="${1}"
+readonly base_rev="${2}"
+
+if [[ "${#}" -ge 3 ]]; then
+    readonly target_rev="${3}"
+else
+    readonly target_rev="$(git rev-parse HEAD)"
+fi
+
+readonly wd="$(mktemp -d)"
+trap "rm -rf ${wd}" EXIT
+
+cd "${wd}"
+
+(
+    git clone "${shabka_path}" base
+    cd base
+    git checkout "${base_rev}"
+)
+
+(
+    git clone "${shabka_path}" target
+    cd target
+    git checkout "${target_rev}"
+)
+
+"${shabka_path}/scripts/build-host.sh" --shabka-path "${wd}/base" "${host}" --out-link base-result
+"${shabka_path}/scripts/build-host.sh" --shabka-path "${wd}/target" "${host}" --out-link target-result
+
+nix-diff "$(nix-store -q --deriver base-result)" "$(nix-store -q --deriver target-result)"

--- a/scripts/diff-host.sh
+++ b/scripts/diff-host.sh
@@ -46,7 +46,15 @@ cd "${wd}"
     git checkout "${target_rev}"
 )
 
-"${shabka_path}/scripts/build-host.sh" --shabka-path "${wd}/base" "${host}" --out-link base-result
-"${shabka_path}/scripts/build-host.sh" --shabka-path "${wd}/target" "${host}" --out-link target-result
+# build the base
+if ! "${wd}/base/scripts/build-host.sh" "${host}" --out-link base-result; then
+    # probably failed because the base version does not support extra
+    # arguments, in this case `--out-link base-result`. Call it using the
+    # script we already have in this branch now.
+    "${shabka_path}/scripts/build-host.sh" --shabka-path "${wd}/base" "${host}" --out-link base-result
+fi
+
+# build the target
+"${wd}/target/scripts/build-host.sh" "${host}" --out-link target-result
 
 nix-diff "$(nix-store -q --deriver base-result)" "$(nix-store -q --deriver target-result)"


### PR DESCRIPTION
A new script to show the differences in the build of a host against two revisions. Usage: `./scripts/diff-host.sh <host> <base-rev> [target-rev]`. All fields except `target-rev` is required, `target-rev` defaults to the `HEAD`.

```console
 λ  ./scripts/diff-host.sh hades master
 λ  ./scripts/diff-host.sh hades master my-feature-branch
```