### PR TITLE
[home] install Slack not Slack CLI; switch to unstable Slack

### DIFF
--- a/external/nixpkgs/19.03/default.nix
+++ b/external/nixpkgs/19.03/default.nix
@@ -16,4 +16,4 @@ let
     revision = pinnedVersion.rev;
   };
 in
-  (import patched { config = {}; overlays = []; } // { path = patched; })
+  (import patched { config = { allowUnfree = true; }; overlays = []; } // { path = patched; })

--- a/external/nixpkgs/unstable/default.nix
+++ b/external/nixpkgs/unstable/default.nix
@@ -19,4 +19,4 @@ let
     revision = pinnedVersion.rev;
   };
 in
-  (import patched { config = {}; overlays = []; } // { path = patched; })
+  (import patched { config = { allowUnfree = true; }; overlays = []; } // { path = patched; })

--- a/modules/home/software/packages.nix
+++ b/modules/home/software/packages.nix
@@ -47,8 +47,6 @@ in {
     shabka.external.nixpkgs.release-unstable.corgi
     shabka.external.nixpkgs.release-unstable.vgo2nix
 
-    slack
-
     unzip
 
     nix-zsh-completions
@@ -60,6 +58,8 @@ in {
     jetbrains.idea-community
 
     keybase
+
+    slack
 
     # Games
     _2048-in-terminal

--- a/modules/home/software/packages.nix
+++ b/modules/home/software/packages.nix
@@ -47,11 +47,11 @@ in {
     shabka.external.nixpkgs.release-unstable.corgi
     shabka.external.nixpkgs.release-unstable.vgo2nix
 
+    slack
+
     unzip
 
     nix-zsh-completions
-
-    shabka.external.nixpkgs.release-unstable.slack-cli
   ] ++ (if stdenv.isLinux then [
     #
     # Linux applications

--- a/overlays/slack.nix
+++ b/overlays/slack.nix
@@ -1,0 +1,5 @@
+self: super:
+
+{
+  slack = super.shabka.external.nixpkgs.release-unstable.slack;
+}


### PR DESCRIPTION
Without Slack installed, xdg-open cannot find the handler of slack://
and makes it difficult to login to a new team.