### PR TITLE
[NeoVim] Use gopls as the language server for Go

### DIFF
--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -261,12 +261,12 @@ let g:gist_post_private = 1
 ""
 
 let g:go_fmt_command = "goimports"  " What to run on save.
+let g:go_highlight_build_constraints = 1
+let g:go_highlight_fields = 1
 let g:go_highlight_functions = 1
 let g:go_highlight_methods = 1
-let g:go_highlight_fields = 1
-let g:go_highlight_types = 1
 let g:go_highlight_operators = 1
-let g:go_highlight_build_constraints = 1
+let g:go_highlight_types = 1
 
 " }}}
 "" Gundo{{{

--- a/modules/neovim/init.vim
+++ b/modules/neovim/init.vim
@@ -260,6 +260,7 @@ let g:gist_post_private = 1
 "" Golang{{{
 ""
 
+let g:go_def_mode='gopls'
 let g:go_fmt_command = "goimports"  " What to run on save.
 let g:go_highlight_build_constraints = 1
 let g:go_highlight_fields = 1
@@ -267,6 +268,7 @@ let g:go_highlight_functions = 1
 let g:go_highlight_methods = 1
 let g:go_highlight_operators = 1
 let g:go_highlight_types = 1
+let g:go_info_mode='gopls'
 
 " }}}
 "" Gundo{{{


### PR DESCRIPTION
Configure vim-go to use `gopls` as the language server when working with Go files. This requires the unstable release and is a noop on the 19.03 release.

closes #239 