### PR TITLE
home: ssh: hardening default configuration

### DIFF
--- a/modules/home/software/ssh.nix
+++ b/modules/home/software/ssh.nix
@@ -11,7 +11,7 @@ in {
     enable = mkEnableOption "SSH configurations";
 
     privateSSHPath = mkOption {
-      type = types.path;
+      type = types.nullOr types.path;
       default = null;
       defaultText = ''
         The path to the private SSH module

--- a/modules/home/software/ssh.nix
+++ b/modules/home/software/ssh.nix
@@ -12,6 +12,7 @@ in {
 
     privateSSHPath = mkOption {
       type = types.path;
+      default = null;
       defaultText = ''
         The path to the private SSH module
       '';
@@ -20,7 +21,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    programs.ssh = if (builtins.pathExists cfg.privateSSHPath) then import cfg.privateSSHPath else {
+    programs.ssh = if (cfg.privateSSHPath != null) then import cfg.privateSSHPath else {
         enable = true;
 
         extraConfig = ''

--- a/modules/home/software/ssh.nix
+++ b/modules/home/software/ssh.nix
@@ -19,13 +19,17 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = builtins.pathExists cfg.privateSSHPath;
-        message = "privateSSHPath must exist";
-      }
-    ];
 
-    programs.ssh = if cfg.enable then import cfg.privateSSHPath else {};
+    programs.ssh = if (builtins.pathExists cfg.privateSSHPath) then import cfg.privateSSHPath else {
+        enable = true;
+
+        extraConfig = ''
+          KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+          PubkeyAuthentication yes
+          HostKeyAlgorithms ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa
+          Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+          MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+        '';
+    };
   };
 }


### PR DESCRIPTION
Set the default ssh configuration when no `privateSSHPath` is given to what is recommended by NixOS and other parties :
- https://nixos.org/nixos/options.html#services.openssh
- https://stribika.github.io/2015/01/04/secure-secure-shell.html
- https://infosec.mozilla.org/guidelines/openssh