### PR TITLE
[RFC 0001] Shabka CLI design

### DIFF
--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -47,7 +47,7 @@ We'll discuss the three aspects previously introduced in [Summary](#summary).
 ## `shabka` CLI
 
 The `shabka` CLI will be used by the user to do what they can currently do using
-the tools is the `scripts/` directory. This will allow him to do everything he
+the tools in the `scripts/` directory. This will allow them to do everything they
 could do using the `nixos-rebuild` command, plus building a host, checking what
 changed in his host's generation between two git refs, and maybe even pushing
 his hosts' configurations to Cachix.

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -46,7 +46,7 @@ We'll discuss the three aspects previously introduced in [Summary](#summary).
 
 ## `shabka` CLI
 
-The `shabka` CLI will be used by the user to do what he can currently do using
+The `shabka` CLI will be used by the user to do what they can currently do using
 the tools is the `scripts/` directory. This will allow him to do everything he
 could do using the `nixos-rebuild` command, plus building a host, checking what
 changed in his host's generation between two git refs, and maybe even pushing

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -50,7 +50,7 @@ The `shabka` CLI will be used by the user to do what they can currently do using
 the tools in the `scripts/` directory. This will allow them to do everything they
 could do using the `nixos-rebuild` command, plus building a host, checking what
 changed in their host's generation between two git refs, and maybe even pushing
-his hosts' configurations to Cachix.
+their hosts' configurations to Cachix.
 
 Here is what the CLI usage might look like:
 

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -3,7 +3,13 @@ feature: shabka-usage-design
 start-date: 2019-10-14
 author: Marc 'risson' Schmitt
 co-authors:
-related-issues: https://github.com/kalbasit/shabka/projects/10 https://github.com/kalbasit/shabka/issues/263 https://github.com/kalbasit/shabka/issues/246 https://github.com/kalbasit/shabka/issues/55 https://github.com/kalbasit/shabka/issues/281
+  - Wael 'kalbasit' Nasreddine
+related-issues:
+  - https://github.com/kalbasit/shabka/projects/10
+  - https://github.com/kalbasit/shabka/issues/263
+  - https://github.com/kalbasit/shabka/issues/246
+  - https://github.com/kalbasit/shabka/issues/55
+  - https://github.com/kalbasit/shabka/issues/281
 ---
 
 # Summary
@@ -16,11 +22,9 @@ The tools and ways to configure at the disposition of the user would be those:
 * the command `shabka`, installed like `home-manager` which basically does the
   stuff the user wants to do on a regular basis that we currently have in
   `./scripts` ;
-* a `dotshabka` like directory for the user's personal preferences settings and
-  default values for `shabka` options, or overriding stuff we define in
-  `shabka`. We will refer to this as `dotshabka-user` ;
-* a `dotshabka` like directory for the user's hosts. We will refer to this as
-  `.shabka`.
+* a `dotshabka` like directory for the user's hosts and personal preferences
+  settings and default values for `shabka` options, or overriding stuff we
+  define in `shabka`. We will refer to this as `dotshabka`.
 
 # Motivation
 [motivation]: #motivation
@@ -34,11 +38,13 @@ The planned use cases are very simple for now, and can be described as this:
 * Usage on a NixOS system, with root access.
   - Management of several hosts' configuration
   - Management of several users per-host.
-  - Management of several users' configuration per-host.
+  - Management of a single users's configuration hosts-wide.
+  - Management of a single users' configuration per-host.
 * Usage on a Darwin system, with root access.
   - Management of several hosts' configuration
   - Management of several users per-host.
-  - Management of several users' configuration per-host.
+  - Management of a single users's configuration hosts-wide.
+  - Management of a single users' configuration per-host.
 
 The expected outcome is a tool well-documented, easy to use, that can fit easily
 inside an existing workflow of managing NixOS and home-manager configurations.
@@ -124,46 +130,36 @@ shabka push-to-cachix <cache-name> [host1] [host2] [host3] [...]
 If no host is given, this command will push every host in `.shabka/hosts`. This
 command requires the environment variable `CACHIX_SIGNING_KEY` to be set.
 
-## `dotshabka-user` for a user configuration
+## `dotshabka` for a user's hosts and personal configuration
 
-This directory will be used to define a user's personal configuration.
+This directory will be used to define a user's:
 
-This directory must have a `home.nix` that defines a
-function for the user as its now done in the `home.nix` inside a host's
-configuration. In this `home.nix`, the user can then define their personal
-configuration, using the `home` module in `shabka`, overriding it, or directly
-using `home-manager` configuration options.
-
-There must also be a `default.nix` inside this directory, which imports
-`home.nix` and can then be imported by a `.shabka` repository to be used as a
-user's configuration.
-
-This `default.nix` will later be imported inside a host's configuration, when
-defining `shabka.users.users`, by assigning one function per user. This allows
-for the user of the same host to have different configurations. Also, it makes
-it easy for a user's configuration to be imported in several `.shabka`, and even
-be used outside of the `shabka` use case.
-
-## `.shabka` for hosts configuration
+* hosts ;
+* personal configuration hosts-wide ;
+* personal configuration per-host.
 
 By default, `shabka` will look for this directory in `$HOME/.config/shabka` and
 `$HOME/.shabka`, in this order. This should be configurable in some way. Here
 is the expected structure of the directory:
 
-* `external/`: Nix expressions for fetching externals such as a personal NUR,
-  or a list of your SSH keys.
+* `external/` (optional): Nix expressions for fetching externals such as a
+  personal NUR, or a list of your SSH keys.
 * `hosts/`: top-level expressions specific to individual hosts. The name of the
   host's folder must match its hostname.
 
 Inside a host's directory, `shabka` will expect the following things:
 
-* `.uname`: either containing `Darwin` or `Linux`
 * `default.nix`: used to import the host's configuration
 * `configuration.nix`: The actual host's configuration, where you can use NixOS
   configuration options, and the `nixos` module of `shabka`.
-
-In addition, you can also define the release of `nixpkgs` you want to use
-inside a `.release` file, such as `unstable` or `19.09`.
+* `home.nix` (optional, imported from `configuration.nix`) : defines a
+  function for the user as its now done in the `home.nix` inside a host's
+  configuration. In this `home.nix`, the user can then define their personal
+  configuration, using the `home` module in `shabka`, overriding it, or directly
+  using `home-manager` configuration options.
+* `uname`: either containing `Darwin` or `Linux`
+* `release` (optional, defaults to `shabka/release`): defines the release of
+  `nixpkgs` you want to use, such as `unstable` or `19.09`.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -186,8 +182,10 @@ No alternative has yet been considered.
 The way the `shabka diff` command will work is still a WIP. Making it easy for
 the user to use might not be trivial.
 
+Multi-user usage.
+
 # Future work
 [future]: #future-work
 
 * Rollbacks
-* Non-nixos systems with nix installed
+* Non-NixOS systems with nix installed

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -72,7 +72,7 @@ This will do what `scripts/nixos-rebuild.sh`, or `script/build-host.sh` for
 `build shabka`, currently does. Its usage is:
 
 ```sh
-shabka {switch | boot | test | build | dry-build | dry-activate} [-h host] [-r release] [nixos-rebuild arguments and options]
+shabka [-h host] [-r release] {switch | boot | test | build | dry-build | dry-activate} [nixos-rebuild arguments and options]
 ```
 
 By default the `host` argument is the current hostname, the `release` argument
@@ -92,7 +92,7 @@ respective section of this document.
 This will do what `scripts/darwin-rebuild.sh` currently does. Its usage is:
 
 ```sh
-shabka {switch | activate | build | check} [-h host] [-r release] [darwin-rebuild arguments and options]
+shabka [-h host] [-r release] {switch | activate | build | check} [darwin-rebuild arguments and options]
 ```
 
 By default the `host` argument is the current hostname, the `release` argument

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -32,12 +32,18 @@ allow the user to quickly get a hang on the tool.
 The planned use cases are very simple for now, and can be described as this:
 
 * Usage on a NixOS system, with root access.
-* Management of several hosts' configuration
-* Management of several users per-host.
-* Management of several users' configuration per-host.
+  - Management of several hosts' configuration
+  - Management of several users per-host.
+  - Management of several users' configuration per-host.
+* Usage on a Darwin system, with root access.
+  - Management of several hosts' configuration
+  - Management of several users per-host.
+  - Management of several users' configuration per-host.
 
 The expected outcome is a tool well-documented, easy to use, that can fit easily
 inside an existing workflow of managing NixOS and home-manager configurations.
+The existing configurations would of course need to be tweaked to fit shabka's
+workflow.
 
 # Detailed design
 [design]: #detailed-design
@@ -101,10 +107,11 @@ shabka diff <host> <base-rev> [target-rev]
 
 By default the `target-rev` argument is HEAD.
 
-/!\ This section needs improvement given the fact that we now have 2
-repositories to deal with (`shabka` and `.shabka`, as `dotshabka-user` is
-defined in `.shabka`). This implies a lot of arguments and some designing
-around this command must be done.
+> This section needs improvement given the fact that we now have 2
+> repositories to deal with (`shabka` and `.shabka`, as `dotshabka-user` is
+> defined in `.shabka`). This implies a lot of arguments and some designing
+> around this command must be done. A future RFC will cover the use cases of
+> this command and its design.
 
 ### `shabka push-to-cachix`
 

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -161,7 +161,8 @@ Inside a host's directory, `shabka` will expect the following things:
   configuration. In this `home.nix`, the user can then define their personal
   configuration, using the `home` module in `shabka`, overriding it, or directly
   using `home-manager` configuration options.
-* `uname`: either containing `Darwin` or `Linux`
+* `uname`: either containing `Darwin` or `NixOS` (`Linux` is for non-NixOS
+  hosts and a later release)
 * `release` (optional, defaults to `shabka/release`): defines the release of
   `nixpkgs` you want to use, such as `unstable` or `19.09`.
 

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -49,7 +49,7 @@ We'll discuss the three aspects previously introduced in [Summary](#summary).
 The `shabka` CLI will be used by the user to do what they can currently do using
 the tools in the `scripts/` directory. This will allow them to do everything they
 could do using the `nixos-rebuild` command, plus building a host, checking what
-changed in his host's generation between two git refs, and maybe even pushing
+changed in their host's generation between two git refs, and maybe even pushing
 his hosts' configurations to Cachix.
 
 Here is what the CLI usage might look like:

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -59,49 +59,53 @@ We'll discuss the three aspects previously introduced in [Summary](#summary).
 ## `shabka` CLI
 
 The `shabka` CLI will be used by the user to do what they can currently do using
-the tools in the `scripts/` directory. This will allow them to do everything they
-could do using the `nixos-rebuild` command, plus building a host, checking what
-changed in their host's generation between two git refs, and maybe even pushing
-their hosts' configurations to Cachix.
+the tools in the `scripts/` directory. This will allow them to do everything
+they could do using the `nixos-rebuild` command, plus building a host, checking
+what changed in their host's generation between two git refs, and maybe even
+pushing their hosts' configurations to Cachix.
 
 Here is what the CLI usage might look like:
 
-### `shabka rebuild`
+### On NixOS hosts: `shabka {switch | boot | test | build | dry-build | dry-activate}`
 
-This will do what `scripts/nixos-rebuild.sh` currently does. Its usage is:
+This will do what `scripts/nixos-rebuild.sh`, or `script/build-host.sh` for
+`build shabka`, currently does. Its usage is:
 
 ```sh
-shabka rebuild [-h host] [-r release] {nixos-rebuild arguments and options}
+shabka {switch | boot | test | build | dry-build | dry-activate} [-h host] [-r release] [nixos-rebuild arguments and options]
 ```
 
 By default the `host` argument is the current hostname, the `release` argument
-is the host's release (defined in `.shabka/hosts/{host}/.release`) if
-defined, or `shabka`'s default, defined in `shabka/.release`.
-
-This command takes care of setting all environment variables and options to
-ensure a smooth `nixos-rebuild` depending on what is defined in `shabka`,
-`.shabka` and `dotshabka-user`. The default locations of `.shabka` and
-`dotshabka-user` are defined in their respective section of this document.
-
-### `shabka build`
-
-This will do what `scripts/build-host.sh` currently does. Its usage is:
-
-```sh
-shabka build [-r release] [host]
-```
-
-By default the `host` argument is the current hostname, the `release` argument
-is the host's release (defined in `.hosts/hosts/{host}/.release`) if
-defined, or `shabka`'s default, defined in `shabka/.release`.
+is the host's release (defined in `dotshabka/hosts/{host}/release`) if
+defined, or `shabka`'s default, defined in `shabka/release`.
 
 > This command cannot build a host with a different kernel than the host it is
 > being ran on, e.g. a `Darwin` host cannot be built on a `Linux` host.
 
 This command takes care of setting all environment variables and options to
-ensure a smooth `nix-build` depending on what is defined in `shabka`, `.shabka`
-and `dotshabka-user`. The default locations of `.shabka` and `dotshabka-user`
-are defined in their respective section of this document.
+ensure a smooth `nixos-rebuild` depending on what is defined in `shabka`, and
+`dotshabka`. The default location of `dotshabka` are defined in their
+respective section of this document.
+
+### On Darwin hosts: `shabka {switch | activate | build | check}`
+
+This will do what `scripts/darwin-rebuild.sh` currently does. Its usage is:
+
+```sh
+shabka {switch | activate | build | check} [-h host] [-r release] [darwin-rebuild arguments and options]
+```
+
+By default the `host` argument is the current hostname, the `release` argument
+is the host's release (defined in `dotshabka/hosts/{host}/release`) if
+defined, or `shabka`'s default, defined in `shabka/release`.
+
+> This command cannot build a host with a different kernel than the host it is
+> being ran on, e.g. a `Darwin` host cannot be built on a `Linux` host.
+
+This command takes care of setting all environment variables and options to
+ensure a smooth `darwin-rebuild` depending on what is defined in `shabka`, and
+`dotshabka`. The default location of `dotshabka` are defined in their
+respective section of this document.
 
 ### `shabka diff`
 
@@ -127,8 +131,8 @@ This will do what `scripts/push-to-cachix.sh` currently does. Its usage is:
 shabka push-to-cachix <cache-name> [host1] [host2] [host3] [...]
 ```
 
-If no host is given, this command will push every host in `.shabka/hosts`. This
-command requires the environment variable `CACHIX_SIGNING_KEY` to be set.
+If no host is given, this command will push every host in `dotshabka/hosts`.
+This command requires the environment variable `CACHIX_SIGNING_KEY` to be set.
 
 ## `dotshabka` for a user's hosts and personal configuration
 

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -123,7 +123,7 @@ This directory will be used to define a user's personal configuration.
 
 This directory must have a `home.nix` that defines a
 function for the user as its now done in the `home.nix` inside a host's
-configuration. In this `home.nix`, the user can then define its personal
+configuration. In this `home.nix`, the user can then define their personal
 configuration, using the `home` module in `shabka`, overriding it, or directly
 using `home-manager` configuration options.
 

--- a/rfcs/0001-shabka-usage-design.md
+++ b/rfcs/0001-shabka-usage-design.md
@@ -1,0 +1,183 @@
+---
+feature: shabka-usage-design
+start-date: 2019-10-14
+author: Marc 'risson' Schmitt
+co-authors: Wael 'kalbasit' Nasreddine
+related-issues: https://github.com/kalbasit/shabka/projects/10 https://github.com/kalbasit/shabka/issues/263 https://github.com/kalbasit/shabka/issues/246 https://github.com/kalbasit/shabka/issues/55 https://github.com/kalbasit/shabka/issues/281
+---
+
+# Summary
+[summary]: #summary
+
+The goal is to design a system where `shabka` is just a tool like
+`home-manager`, and relies on configuration files provided by the user.
+The tools and ways to configure at the disposition of the user would be those:
+
+* the command `shabka`, installed like `home-manager` which basically does the
+  stuff the user wants to do on a regular basis that we currently have in
+  `./scripts` ;
+* a `dotshabka` like directory for the user's personal preferences settings and
+  default values for `shabka` options, or overriding stuff we define in
+  `shabka`. We will refer to this as `.shabka` ;
+* a `dotshabka` like directory for the user's hosts. We will refer to this as
+  `.hosts`.
+
+# Motivation
+[motivation]: #motivation
+
+This is important in the process of making `shabka` usable for everyone. A
+simple CLI, plus good documentation on how to create configuration files, will
+allow the user to quickly get a hang on the tool.
+
+The planned use cases are very simple for now, and can be described as this:
+
+* Usage on a NixOS system, with root access.
+* Management of several hosts' configuration
+* Management of several users per-host.
+* Management of several users' configuration per-host.
+
+The expected outcome is a tool well-documented, easy to use, that can fit easily
+inside an existing workflow of managing NixOS and home-manager configurations.
+
+# Detailed design
+[design]: #detailed-design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with the ecosystem to understand, and implement.  This should get
+into specifics and corner-cases, and include examples of how the feature is
+used.
+
+We'll discuss the three aspects previously introduced in [Summary](#summary).
+
+## `shabka` CLI
+
+The `shabka` CLI will be used by the user to do what he can currently do using
+the tools is the `scripts/` directory. This will allow him to do everything he
+could do using the `nixos-rebuild` command, plus building a host, checking what
+changed in his host's generation between two git refs, and maybe even pushing
+his hosts' configurations to Cachix.
+
+Here is what the CLI usage might look like:
+
+### `shabka rebuild`
+
+This will do what `scripts/nixos-rebuild.sh` currently does. Its usage is:
+
+```sh
+shabka rebuild [-h host] [-r release] {nixos-rebuild arguments and options}
+```
+
+By default the `host` argument is the current hostname, the `release` argument
+is the host's release (defined in `.hosts/hosts/{host}/.release`) if
+defined, or `shabka`'s default, defined in `shabka/.release`.
+
+This command takes care of setting all environment variables and options to
+ensure a smooth `nixos-rebuild` depending on what is defined in `shabka`,
+`.hosts` and `.shabka`. The default locations of `.hosts` and `.shabka` are
+defined in their respective section of this document.
+
+### `shabka build`
+
+This will do what `scripts/build-host.sh` currently does. Its usage is:
+
+```sh
+shabka build [-r release] [host]
+```
+
+By default the `host` argument is the current hostname, the `release` argument
+is the host's release (defined in `.hosts/hosts/{host}/.release`) if
+defined, or `shabka`'s default, defined in `shabka/.release`.
+
+> This command cannot build a host with a different kernel than the host it is
+> being ran on, e.g. a `Darwin` host cannot be built on a `Linux` host.
+
+This command takes care of setting all environment variables and options to
+ensure a smooth `nix-build` depending on what is defined in `shabka`, `.hosts`
+and `.shabka`. The default locations of `.hosts` and `.shabka` are defined in
+their respective section of this document.
+
+### `shabka diff`
+
+This will do what `scripts/diff-host.sh` used to do. Its usage is:
+
+```sh
+shabka diff <host> <base-rev> [target-rev]
+```
+
+By default the `target-rev` argument is HEAD.
+
+/!\ This section needs improvement given the fact that we now have 3
+repositories to deal with. This implies a lot of arguments and some designing
+around this command must be done.
+
+### `shabka push-to-cachix`
+
+This will do what `scripts/push-to-cachix.sh` currently does. Its usage is:
+
+```sh
+shabka push-to-cachix <cache-name> [host1] [host2] [host3] [...]
+```
+
+If no host is given, this command will push every host in `.hosts/hosts`. This
+command requires `CACHIX_SIGNING_KEY` to be set.
+
+## `.shabka` for a user configuration
+
+This directory will be used to define a user's personal configuration.
+
+This directory must have a `home.nix` that defines a
+function for the user as its now done in the `home.nix` inside a host's
+configuration. In this `home.nix`, the user can then define its personal
+configuration, using the `home` module in `shabka`, overriding it, or directly
+using `home-manager` configuration options.
+
+This `home.nix` will later be imported inside a host's configuration, when
+defining `shabka.users.users`, by assigning one function per user. This allows
+for the user of the same host to have different configurations. Also, it makes
+it easy for a user's configuration to be imported in several `.hosts`, and even
+be used outside of the `shabka` use case.
+
+## `.hosts` for hosts configuration
+
+By default, `shabka` will look for this directory in `~/.config/hosts` and
+`~/.hosts`, in this order. This should be configurable in some way. Here is the
+expected structure of the directory:
+
+* `external/`: Nix expressions for fetching externals such as a personal NUR,
+  or a list of your SSH keys.
+* `hosts/`: top-level expressions specific to individual hosts. The name of the
+  host's folder must match its hostname.
+
+Inside a host's directory, `shabka` will expect the following things:
+
+* `.uname`: either containing `Darwin` or `Linux`
+* `default.nix`
+* `configuration.nix`: The actual host's configuration, where you can use NixOS
+  configuration options, and the `nixos` module of `shabka`.
+
+In addition, you can also define the release of `nixpkgs` you want to use
+inside a `.release` file, such as `unstable` or `19.09`.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+[alternatives]: #alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+What parts of the design are still TBD or unknowns?
+
+# Future work
+[future]: #future-work
+
+* Rollbacks
+* non-nixos systems with nix installed
+
+What future work, if any, would be implied or impacted by this feature
+without being directly part of the work?

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,6 @@
+# shabka RFCs
+
+The RFCs posted in this directory are meant to be used like they are in the [NixOS/rfcs](https://github.com/NixOS/rfcs) repository.
+Please read the README over there before getting started.
+
+A template to get started is available [here](https://github.com/NixOS/rfcs/blob/master/0000-template.md).


### PR DESCRIPTION
Closes #263.

Relevant issues: #246 #55 #281 

The goal is to design a system where `shabka` is just a tool like
`home-manager`, and relies on configuration files provided by the user.
The tools and ways to configure at the disposition of the user would be those:

* the command `shabka`, installed like `home-manager` which basically does the
  stuff the user wants to do on a regular basis that we currently have in
  `./scripts` ;
* a `dotshabka` like directory for the user's personal preferences settings and
  default values for `shabka` options, or overriding stuff we define in
  `shabka`. We will refer to this as `.shabka` ;
* a `dotshabka` like directory for the user's hosts. We will refer to this as
  `.hosts`.