### PR TITLE
scripts/push-to-cachix: improvements (#285)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 var_0: &global_env
+  PLACEHOLDER: for_future_use
 
 var_1: &install-nix
   run:
@@ -67,7 +68,7 @@ var_5: &push-to-cachix
 
       export DOTSHABKA_PATH="${HOME}/dotshabka"
 
-      ./scripts/push-to-cachix.sh "${CIRCLE_JOB}"
+      ./scripts/push-to-cachix.sh "${CACHIX_CACHE}" "${CIRCLE_JOB}"
 
 var_6: &download-kalbasit-dotshabka
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,16 @@
-var_0: &global_env_kalbasit
-  CACHIX_CACHE: yl
+var_0: &setup_env_kalbasit
+  run:
+    name: Setup environment variables for kalbasit's hosts
+    command: |
+      echo "export CACHIX_CACHE=yl" >> $BASH_ENV
+      echo "export CACHIX_SIGNING_KEY=\"${CACHIX_SIGNING_KEY}\"" >> $BASH_ENV
 
-var_1: &global_env_risson
-  CACHIX_CACHE: risson
+var_1: &setup_env_risson
+  run:
+    name: Setup environment variables for risson's hosts
+    command: |
+      echo "export CACHIX_CACHE=risson" >> $BASH_ENV
+      echo "export CACHIX_SIGNING_KEY=\"${RISSON_CACHIX_SIGNING_KEY}\"" >> $BASH_ENV
 
 var_2: &install-nix
   run:
@@ -50,7 +58,7 @@ var_5: &build-host
 
       ./scripts/build-host.sh "${CIRCLE_JOB}"
 
-var_6: &push-to-cachix-yl
+var_6: &push-to-cachix
   run:
     name: Push the build to cachix
     working_directory: ~/shabka
@@ -59,10 +67,10 @@ var_6: &push-to-cachix-yl
         source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
       fi
 
-      # The YL_CACHIX_SIGNING_KEY is not available for pull requests coming from a
+      # The CACHIX_SIGNING_KEY is not available for pull requests coming from a
       # fork for security reasons.
-      if [[ -z "${YL_CACHIX_SIGNING_KEY:-}" ]]; then
-        >&2 echo "YL_CACHIX_SIGNING_KEY is not set, cannot push to cachix"
+      if [[ -z "${CACHIX_SIGNING_KEY:-}" ]]; then
+        >&2 echo "CACHIX_SIGNING_KEY is not set, cannot push to cachix"
         exit 0
       fi
 
@@ -70,27 +78,7 @@ var_6: &push-to-cachix-yl
 
       ./scripts/push-to-cachix.sh "${CACHIX_CACHE}" "${CIRCLE_JOB}"
 
-var_7: &push-to-cachix-risson
-  run:
-    name: Push the build to cachix
-    working_directory: ~/shabka
-    command: |
-      if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
-        source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
-      fi
-
-      # The RISSON_CACHIX_SIGNING_KEY is not available for pull requests coming from a
-      # fork for security reasons.
-      if [[ -z "${RISSON_CACHIX_SIGNING_KEY:-}" ]]; then
-        >&2 echo "RISSON_CACHIX_SIGNING_KEY is not set, cannot push to cachix"
-        exit 0
-      fi
-
-      export DOTSHABKA_PATH="${HOME}/dotshabka"
-
-      ./scripts/push-to-cachix.sh "${CACHIX_CACHE}" "${CIRCLE_JOB}"
-
-var_8: &download-kalbasit-dotshabka
+var_7: &download-kalbasit-dotshabka
   run:
     name: Download dotshabka from kalbasit
     working_directory: ~/
@@ -110,68 +98,76 @@ jobs:
 
     working_directory: ~/shabka
 
+    shell: /bin/sh -leo pipefail
     environment:
-      <<: *global_env_kalbasit
+      BASH_ENV: /etc/profile
 
     steps:
       - checkout
+      - *setup_env_kalbasit
       - *install-nix
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix-yl
+      - *push-to-cachix
 
   cratos:
     working_directory: ~/shabka
 
+    shell: /bin/sh -leo pipefail
     environment:
-      <<: *global_env_kalbasit
+      BASH_ENV: /etc/profile
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
+      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix-yl
+      - *push-to-cachix
 
   hades:
     working_directory: ~/shabka
 
+    shell: /bin/sh -leo pipefail
     environment:
-      <<: *global_env_kalbasit
+      BASH_ENV: /etc/profile
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
+      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix-yl
+      - *push-to-cachix
 
   hera:
     working_directory: ~/shabka
 
+    shell: /bin/sh -leo pipefail
     environment:
-      <<: *global_env_kalbasit
+      BASH_ENV: /etc/profile
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
+      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix-yl
+      - *push-to-cachix
 
   poseidon:
     macos:
@@ -179,34 +175,38 @@ jobs:
 
     working_directory: ~/shabka
 
+    shell: /bin/sh -leo pipefail
     environment:
-      <<: *global_env_kalbasit
+      BASH_ENV: /etc/profile
 
     steps:
       - checkout
+      - *setup_env_kalbasit
       - *install-nix
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix-yl
+      - *push-to-cachix
 
   zeus:
     working_directory: ~/shabka
 
+    shell: /bin/sh -leo pipefail
     environment:
-      <<: *global_env_kalbasit
+      BASH_ENV: /etc/profile
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
+      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix-yl
+      - *push-to-cachix
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 var_0: &global_env
-  CACHIX_CACHE: yl
 
 var_1: &install-nix
   run:
@@ -56,10 +55,13 @@ var_5: &push-to-cachix
         source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
       fi
 
-      # The CACHIX_SIGNING_KEY is not available for pull requests coming from a
-      # fork for security reasons.
+      # Cachix is not available for pull requests coming from a fork for security reasons.
       if [[ -z "${CACHIX_SIGNING_KEY:-}" ]]; then
         >&2 echo "CACHIX_SIGNING_KEY is not set, cannot push to cachix"
+        exit 0
+      fi
+      if [[ -z "${CACHIX_CACHE:-}" ]]; then
+        >&2 echo "CACHIX_CACHE is not set, cannot push to cachix"
         exit 0
       fi
 
@@ -190,14 +192,14 @@ workflows:
   testing:
     jobs:
       - athena:
-          context: nix-global
+          context: shabka-yl
       - cratos:
-          context: nix-global
+          context: shabka-yl
       - hades:
-          context: nix-global
+          context: shabka-yl
       - hera:
-          context: nix-global
+          context: shabka-yl
       - poseidon:
-          context: nix-global
+          context: shabka-yl
       - zeus:
-          context: nix-global
+          context: shabka-yl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,16 @@
-var_0: &global_env
+var_0: &global_env_kalbasit
   CACHIX_CACHE: yl
 
-var_1: &install-nix
+var_1: &global_env_risson
+  CACHIX_CACHE: risson
+
+var_2: &install-nix
   run:
     name: Install Nix
     command: |
       curl https://nixos.org/nix/install | sh
 
-var_2: &install-dependencies
+var_3: &install-dependencies
   run:
     name: Install dependencies
     command: |
@@ -24,7 +27,7 @@ var_2: &install-dependencies
       export NIX_PATH="$( "${shabka_path}/lib/bash/nix-path.sh" "${release}" )"
       nix-env -f '<nixpkgs>' -iA cachix
 
-var_3: &enable-cachix
+var_4: &enable-cachix
   run:
     name: Enable cachix
     command: |
@@ -34,7 +37,7 @@ var_3: &enable-cachix
 
       cachix use "${CACHIX_CACHE}"
 
-var_4: &build-host
+var_5: &build-host
   run:
     name: Building the host
     working_directory: ~/shabka
@@ -47,7 +50,7 @@ var_4: &build-host
 
       ./scripts/build-host.sh "${CIRCLE_JOB}"
 
-var_5: &push-to-cachix
+var_6: &push-to-cachix-yl
   run:
     name: Push the build to cachix
     working_directory: ~/shabka
@@ -56,18 +59,38 @@ var_5: &push-to-cachix
         source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
       fi
 
-      # The CACHIX_SIGNING_KEY is not available for pull requests coming from a
+      # The YL_CACHIX_SIGNING_KEY is not available for pull requests coming from a
       # fork for security reasons.
-      if [[ -z "${CACHIX_SIGNING_KEY:-}" ]]; then
-        >&2 echo "CACHIX_SIGNING_KEY is not set, cannot push to cachix"
+      if [[ -z "${YL_CACHIX_SIGNING_KEY:-}" ]]; then
+        >&2 echo "YL_CACHIX_SIGNING_KEY is not set, cannot push to cachix"
         exit 0
       fi
 
       export DOTSHABKA_PATH="${HOME}/dotshabka"
 
-      ./scripts/push-to-cachix.sh "${CIRCLE_JOB}"
+      ./scripts/push-to-cachix.sh "${CACHIX_CACHE}" "${CIRCLE_JOB}"
 
-var_6: &download-kalbasit-dotshabka
+var_7: &push-to-cachix-risson
+  run:
+    name: Push the build to cachix
+    working_directory: ~/shabka
+    command: |
+      if [[ -r "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]]; then
+        source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+      fi
+
+      # The RISSON_CACHIX_SIGNING_KEY is not available for pull requests coming from a
+      # fork for security reasons.
+      if [[ -z "${RISSON_CACHIX_SIGNING_KEY:-}" ]]; then
+        >&2 echo "RISSON_CACHIX_SIGNING_KEY is not set, cannot push to cachix"
+        exit 0
+      fi
+
+      export DOTSHABKA_PATH="${HOME}/dotshabka"
+
+      ./scripts/push-to-cachix.sh "${CACHIX_CACHE}" "${CIRCLE_JOB}"
+
+var_8: &download-kalbasit-dotshabka
   run:
     name: Download dotshabka from kalbasit
     working_directory: ~/
@@ -88,7 +111,7 @@ jobs:
     working_directory: ~/shabka
 
     environment:
-      <<: *global_env
+      <<: *global_env_kalbasit
 
     steps:
       - checkout
@@ -97,13 +120,13 @@ jobs:
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix
+      - *push-to-cachix-yl
 
   cratos:
     working_directory: ~/shabka
 
     environment:
-      <<: *global_env
+      <<: *global_env_kalbasit
 
     docker:
       - image: nixos/nix
@@ -114,13 +137,13 @@ jobs:
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix
+      - *push-to-cachix-yl
 
   hades:
     working_directory: ~/shabka
 
     environment:
-      <<: *global_env
+      <<: *global_env_kalbasit
 
     docker:
       - image: nixos/nix
@@ -131,13 +154,13 @@ jobs:
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix
+      - *push-to-cachix-yl
 
   hera:
     working_directory: ~/shabka
 
     environment:
-      <<: *global_env
+      <<: *global_env_kalbasit
 
     docker:
       - image: nixos/nix
@@ -148,7 +171,7 @@ jobs:
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix
+      - *push-to-cachix-yl
 
   poseidon:
     macos:
@@ -157,7 +180,7 @@ jobs:
     working_directory: ~/shabka
 
     environment:
-      <<: *global_env
+      <<: *global_env_kalbasit
 
     steps:
       - checkout
@@ -166,13 +189,13 @@ jobs:
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix
+      - *push-to-cachix-yl
 
   zeus:
     working_directory: ~/shabka
 
     environment:
-      <<: *global_env
+      <<: *global_env_kalbasit
 
     docker:
       - image: nixos/nix
@@ -183,7 +206,7 @@ jobs:
       - *enable-cachix
       - *download-kalbasit-dotshabka
       - *build-host
-      - *push-to-cachix
+      - *push-to-cachix-yl
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,13 @@
-var_0: &setup_env_kalbasit
-  run:
-    name: Setup environment variables for kalbasit's hosts
-    command: |
-      echo "export CACHIX_CACHE=yl" >> $BASH_ENV
-      echo "export CACHIX_SIGNING_KEY=\"${CACHIX_SIGNING_KEY}\"" >> $BASH_ENV
+var_0: &global_env
+  CACHIX_CACHE: yl
 
-var_1: &setup_env_risson
-  run:
-    name: Setup environment variables for risson's hosts
-    command: |
-      echo "export CACHIX_CACHE=risson" >> $BASH_ENV
-      echo "export CACHIX_SIGNING_KEY=\"${RISSON_CACHIX_SIGNING_KEY}\"" >> $BASH_ENV
-
-var_2: &install-nix
+var_1: &install-nix
   run:
     name: Install Nix
     command: |
       curl https://nixos.org/nix/install | sh
 
-var_3: &install-dependencies
+var_2: &install-dependencies
   run:
     name: Install dependencies
     command: |
@@ -35,7 +24,7 @@ var_3: &install-dependencies
       export NIX_PATH="$( "${shabka_path}/lib/bash/nix-path.sh" "${release}" )"
       nix-env -f '<nixpkgs>' -iA cachix
 
-var_4: &enable-cachix
+var_3: &enable-cachix
   run:
     name: Enable cachix
     command: |
@@ -45,7 +34,7 @@ var_4: &enable-cachix
 
       cachix use "${CACHIX_CACHE}"
 
-var_5: &build-host
+var_4: &build-host
   run:
     name: Building the host
     working_directory: ~/shabka
@@ -58,7 +47,7 @@ var_5: &build-host
 
       ./scripts/build-host.sh "${CIRCLE_JOB}"
 
-var_6: &push-to-cachix
+var_5: &push-to-cachix
   run:
     name: Push the build to cachix
     working_directory: ~/shabka
@@ -76,9 +65,9 @@ var_6: &push-to-cachix
 
       export DOTSHABKA_PATH="${HOME}/dotshabka"
 
-      ./scripts/push-to-cachix.sh "${CACHIX_CACHE}" "${CIRCLE_JOB}"
+      ./scripts/push-to-cachix.sh "${CIRCLE_JOB}"
 
-var_7: &download-kalbasit-dotshabka
+var_6: &download-kalbasit-dotshabka
   run:
     name: Download dotshabka from kalbasit
     working_directory: ~/
@@ -98,13 +87,11 @@ jobs:
 
     working_directory: ~/shabka
 
-    shell: /bin/sh -leo pipefail
     environment:
-      BASH_ENV: /etc/profile
+      <<: *global_env
 
     steps:
       - checkout
-      - *setup_env_kalbasit
       - *install-nix
       - *install-dependencies
       - *enable-cachix
@@ -115,16 +102,14 @@ jobs:
   cratos:
     working_directory: ~/shabka
 
-    shell: /bin/sh -leo pipefail
     environment:
-      BASH_ENV: /etc/profile
+      <<: *global_env
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
-      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
@@ -134,16 +119,14 @@ jobs:
   hades:
     working_directory: ~/shabka
 
-    shell: /bin/sh -leo pipefail
     environment:
-      BASH_ENV: /etc/profile
+      <<: *global_env
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
-      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
@@ -153,16 +136,14 @@ jobs:
   hera:
     working_directory: ~/shabka
 
-    shell: /bin/sh -leo pipefail
     environment:
-      BASH_ENV: /etc/profile
+      <<: *global_env
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
-      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka
@@ -175,13 +156,11 @@ jobs:
 
     working_directory: ~/shabka
 
-    shell: /bin/sh -leo pipefail
     environment:
-      BASH_ENV: /etc/profile
+      <<: *global_env
 
     steps:
       - checkout
-      - *setup_env_kalbasit
       - *install-nix
       - *install-dependencies
       - *enable-cachix
@@ -192,16 +171,14 @@ jobs:
   zeus:
     working_directory: ~/shabka
 
-    shell: /bin/sh -leo pipefail
     environment:
-      BASH_ENV: /etc/profile
+      <<: *global_env
 
     docker:
       - image: nixos/nix
 
     steps:
       - checkout
-      - *setup_env_kalbasit
       - *install-dependencies
       - *enable-cachix
       - *download-kalbasit-dotshabka

--- a/scripts/push-to-cachix.sh
+++ b/scripts/push-to-cachix.sh
@@ -35,6 +35,11 @@ if [[ -z "${CACHIX_SIGNING_KEY:-}" ]]; then
     exit 1
 fi
 
+usage () {
+    >&2 echo "Usage: ${0} binary-cache-name [HOST]"
+    exit 2
+}
+
 push_host() {
     local host="${1}"
     local release
@@ -64,9 +69,16 @@ push_host() {
     echo -e "\tNIX_PATH=${nix_path}"
     NIX_PATH="${nix_path}" \
     RELEASE="release-${release/./-}" \
-        nix-build --option builders '' "${dotshabka_path}/hosts/${host}" -A system | cachix push yl
+        nix-build --option builders '' "${dotshabka_path}/hosts/${host}" -A system | cachix push "${binary_cache_name}"
 }
 
+if [[ "${#}" -lt 1 ]]; then
+    >&2 echo "ERR: No cachix binary cache specified"
+    usage
+fi
+
+readonly binary_cache_name="${1}"
+shift 1
 
 if [[ "${#}" -eq 1 ]]; then
     push_host "${1}"

--- a/scripts/push-to-cachix.sh
+++ b/scripts/push-to-cachix.sh
@@ -2,9 +2,15 @@
 
 set -euo pipefail
 
+# check that cachix CLI tool is installed
+if ! command -v cachix >/dev/null 2>&1; then
+    >&2 echo "ERR: Cachix CLI tool is required to push to Cachix!"
+    exit 1
+fi
+
 # find .shabka
 if [[ "x$(printenv DOTSHABKA_PATH)" == "x" ]]; then
-    >&2 echo "Please define DOTSHABKA_PATH to point to the location of your .shabka"
+    >&2 echo "ERR: Please define DOTSHABKA_PATH to point to the location of your .shabka"
     exit 1
 fi
 readonly dotshabka_path="${DOTSHABKA_PATH}"


### PR DESCRIPTION
Closes #285 

If accepted, the CI env variables `CACHIX_SIGNING_KEY` must be moved to `YL_CACHIX_SIGNING_KEY`, and `RISSON_CACHIX_SIGNING_KEY` must be added to allow for risson's hosts to be pushed to his cachix. 