### PR TITLE
nixos/darwin: switch to using binary cache over HTTP

### DIFF
--- a/modules/darwin/general/nix.nix
+++ b/modules/darwin/general/nix.nix
@@ -23,7 +23,6 @@ in {
     ];
 
     binaryCachePublicKeys = [
-      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "yl.cachix.org-1:Abr5VClgHbNd2oszU+ivr+ujB0Jt2swLo2ddoeSMkm0="
       "risson.cachix.org-1:x5ge8Xn+YFlaEqQr3oHhMXxHPYSXbG2k2XFtGqGemwg="
     ];

--- a/modules/darwin/general/nix.nix
+++ b/modules/darwin/general/nix.nix
@@ -17,12 +17,15 @@ in {
     ];
 
     binaryCaches = [
-      "https://cache.nixos.org/"
-      "https://yl.cachix.org"
+      "http://cache.nixos.org"
+      "http://yl.cachix.org"
+      "http://risson.cachix.org"
     ];
 
     binaryCachePublicKeys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "yl.cachix.org-1:Abr5VClgHbNd2oszU+ivr+ujB0Jt2swLo2ddoeSMkm0="
+      "risson.cachix.org-1:x5ge8Xn+YFlaEqQr3oHhMXxHPYSXbG2k2XFtGqGemwg="
     ];
   };
 

--- a/modules/nixos/general/nix.nix
+++ b/modules/nixos/general/nix.nix
@@ -35,7 +35,6 @@ in {
     ];
 
     binaryCachePublicKeys = [
-      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "yl.cachix.org-1:Abr5VClgHbNd2oszU+ivr+ujB0Jt2swLo2ddoeSMkm0="
       "risson.cachix.org-1:x5ge8Xn+YFlaEqQr3oHhMXxHPYSXbG2k2XFtGqGemwg="
     ];

--- a/modules/nixos/general/nix.nix
+++ b/modules/nixos/general/nix.nix
@@ -29,12 +29,13 @@ in {
     };
 
     binaryCaches = [
-      "https://cache.nixos.org/"
-      "https://yl.cachix.org"
-      "https://risson.cachix.org"
+      "http://cache.nixos.org"
+      "http://yl.cachix.org"
+      "http://risson.cachix.org"
     ];
 
     binaryCachePublicKeys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "yl.cachix.org-1:Abr5VClgHbNd2oszU+ivr+ujB0Jt2swLo2ddoeSMkm0="
       "risson.cachix.org-1:x5ge8Xn+YFlaEqQr3oHhMXxHPYSXbG2k2XFtGqGemwg="
     ];


### PR DESCRIPTION
By using caches over HTTP, it allows us to spawn up a local binary cache for bandwidth savings. Although HTTP does not prevent MITM attacks, all of the cached binaries are signed. If the signature does not match, nix will reject it and move on to the next cache.

Setting these values does not remove the default cache `https://cache.nixos.org`, but if it does not resolve (like in the case of local cache) it will get ignored.

Leaving the command to use on my local network to switch existing hosts as HTTPS no longer resolves:

```
sudo --preserve-env=DOTSHABKA_PATH ./bin/shabka boot --option binary-caches 'http://cache.nixos.org http://yl.cachix.org http://risson.cachix.org' --option trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= yl.cachix.org-1:Abr5VClgHbNd2oszU+ivr+ujB0Jt2swLo2ddoeSMkm0= risson.cachix.org-1:x5ge8Xn+YFlaEqQr3oHhMXxHPYSXbG2k2XFtGqGemwg='
```