### PR TITLE
modules: home: workstation: i3: polybar: disable warning log output

### DIFF
--- a/modules/home/workstation/i3/bar/polybar.lib.nix
+++ b/modules/home/workstation/i3/bar/polybar.lib.nix
@@ -17,7 +17,7 @@ let
 
     for m in $(${pkgs.xorg.xrandr}/bin/xrandr --query | ${pkgs.gnugrep}/bin/grep " connected" | ${pkgs.coreutils}/bin/cut -d" " -f1); do
       echo "Starting polybar on monitor $m"
-      MONITOR=$m polybar --reload default &
+      MONITOR=$m polybar -q --log=error --reload default &
     done
   '';
 


### PR DESCRIPTION
This is a temporary fix. A more permanent one would be to choose a font
supporting all characters used by our polybar configuration. But for
now, this is required so we don't have a bloated journal due to polybar
warnings about unmatched characters.

Adding TODO in #247 to improve the font used.

Closes #308 