### PR TITLE
bin/shabka: add dotshabka to NIX_PATH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ var_3: &install-cachix
 
       # install cachix from nixpkgs at stable
       readonly shabka_path="$( pwd )"
+      readonly dotshabka_path="placeholder"
       release="$( tr -d "\n" < "${shabka_path}/release" )"
 
       source "${shabka_path}/bin/shabka"

--- a/bin/shabka
+++ b/bin/shabka
@@ -146,7 +146,7 @@ getHostDistrib() {
 getNixPath() {
   desc="Compute the NIX_PATH from release and distribution.
         Usage: getNixPath <release> <distrib>
-        Requires shabka_path to be set."
+        Requires shabka_path and dotshabka_path to be set."
 
   local -r nixpkgs_release="${1}"
   local -r host_distrib="${2}"
@@ -155,7 +155,7 @@ getNixPath() {
   local -r nixpkgs="$( set -e;
                        nix-build --no-out-link "${shabka_path}" \
                        -A "external.nixpkgs.release-${release/./-}.path" )"
-  local nix_path="nixpkgs=${nixpkgs}:shabka=${shabka_path}"
+  local nix_path="nixpkgs=${nixpkgs}:shabka=${shabka_path}:dotshabka=${dotshabka_path}"
   echoDebug2 "nix_path set with nixpkgs and shabka to '${nix_path}'"
 
   if [[ -z "${host_distrib:-}" ]] || [[ "${host_distrib}" == "Darwin" ]]; then


### PR DESCRIPTION
This allows to do `dotshabka = import <dotshabka> {};` instead of  `dotshabka = import ../.. {};`.

It also allows to do `with <dotshabka/external>;`.