### PR TITLE
bin/shabka: add exec command

### DIFF
--- a/bin/shabka
+++ b/bin/shabka
@@ -48,6 +48,10 @@ echoUsage() {
   >&2 echo -e -n "\tshabka [-h host] [-r release] build "
   >&2 echo -e -n "[nix-build arguments and options]\n\n"
 
+  >&2 echo "Command exec"
+  >&2 echo -e -n "\tshabka [-h host] [-r release] exec <command> "
+  >&2 echo -e -n "[<command> arguments and options]\n\n"
+
   >&2 echo "Command push-to-cachix"
   >&2 echo -e -n "\tshabka push-to-cachix <cache-name> [host1] [host2] [...]\n"
   >&2 echo -e -n "\tIf no host is specified, it defaults to all hosts defined in "
@@ -348,6 +352,40 @@ pushToCachix() {
   echoSuccess "Finished pushing all hosts to Cachix ${binary_cache_name}"
 }
 
+doExec() {
+  desc="Execute a command
+        Usage: doExec <host> <release> <command> [command arguments]
+        Requires shabka_path and dotshabka_path to be set."
+
+  local -r host="${1}"
+  local release="${2}"
+  shift 2
+  local distrib
+  local configPath
+
+  if [[ ! -e "${dotshabka_path}/secrets" ]]; then
+    echoWarn "${dotshabka_path}/secrets does not exist."
+  fi
+
+  distrib="$( getHostDistrib "${host}" )" || exit "${?}"
+
+  if [[ -z "${release:-}" ]]; then
+    echoDebug2 "Release not set, setting it from the host's."
+    release="$( getHostRelease "${host}" )" || exit "${?}"
+  else
+    echoDebug2 "Using provided release."
+    release="${release}"
+  fi
+
+  export NIX_PATH="$( getNixPath "${release}" "${distrib}" )" || exit "${?}"
+
+  configPath="$( getConfigPath "${host}" )" || exit "${?}"
+  export NIX_PATH="${NIX_PATH}:nixos-config=${configPath}"
+
+  RELEASE="release-${release/./-}" \
+    "${@}"
+}
+
 main() {
   if [[ "$#" -eq 0 ]]; then
     echoUsage
@@ -417,6 +455,9 @@ main() {
       shift 1
 
       pushToCachix "${binary_cache_name}" "${release}" "${@}"
+      ;;
+    "exec")
+      doExec "${host}" "${release}" "${@}"
       ;;
     *)
       echoErr "Unkown command: ${command}"


### PR DESCRIPTION
This allows to execute command like this:

```
DOTSHABKA_PATH=/whatever shabka exec nixos-rebuild switch
DOTSHABKA_PATH=/whatever shabka -h your-host exec nixos-rebuild test
DOTSHABKA_PATH=/whatever shabka exec nixops deploy # not tested
DOTSHABKA_PATH=/whatever shabka exec morph deploy
```