### PR TITLE
CircleCI Deprecation Notice: Xcode 9.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ version: 2
 jobs:
   athena:
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
 
     working_directory: ~/shabka
 
@@ -173,7 +173,7 @@ jobs:
 
   poseidon:
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
 
     working_directory: ~/shabka
 


### PR DESCRIPTION
Hello! This is Adam from CircleCI 👋 

We are opening a PR to let you know that your project is using a version of Xcode that we are deprecating. This image is due for removal on 5 October 2020. After this date, jobs that request this image will begin to fail.

This PR updates your config file to Xcode 9.4.1, however we strongly suggest that you update to Xcode 10 or higher if you can.

For more information about this, please see our [announcement](https://discuss.circleci.com/t/deprecation-notice-xcode-9-0-1-and-xcode-9-3-1/37382)